### PR TITLE
refactor: use quic-rpc v0.15.0 and adapt code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,6 +246,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1720,7 +1729,7 @@ dependencies = [
  "portable-atomic",
  "postcard",
  "proptest",
- "quic-rpc",
+ "quic-rpc 0.13.0 (git+https://github.com/n0-computer/quic-rpc.git?branch=map-transports-not-services)",
  "quic-rpc-derive",
  "rand",
  "range-collections",
@@ -2951,13 +2960,37 @@ dependencies = [
 ]
 
 [[package]]
+name = "quic-rpc"
+version = "0.13.0"
+source = "git+https://github.com/n0-computer/quic-rpc.git?branch=map-transports-not-services#c30ba6a08c3ec0e1a05ff6f15a1681cd75ddcf0f"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "derive_more",
+ "educe",
+ "flume",
+ "futures-lite 2.3.0",
+ "futures-sink",
+ "futures-util",
+ "hex",
+ "iroh-quinn",
+ "pin-project",
+ "serde",
+ "slab",
+ "tokio",
+ "tokio-serde",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "quic-rpc-derive"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94b91a3f7a42657cbfbd0c2499c1f037738eff45bb7f59c6ce3d3d9e890d141c"
 dependencies = [
  "proc-macro2",
- "quic-rpc",
+ "quic-rpc 0.13.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "quote",
  "syn 1.0.109",
 ]
@@ -4182,6 +4215,21 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "tokio",
+]
+
+[[package]]
+name = "tokio-serde"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
+dependencies = [
+ "bincode",
+ "bytes",
+ "educe",
+ "futures-core",
+ "futures-sink",
+ "pin-project",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -246,15 +246,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "597bb81c80a54b6a4381b23faba8d7774b144c94cbd1d6fe3f1329bd776554ab"
 
 [[package]]
-name = "bincode"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
-dependencies = [
- "serde",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1270,25 +1261,6 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "h2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
@@ -1507,30 +1479,6 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
-version = "0.14.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.26",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
@@ -1538,7 +1486,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2 0.4.6",
+ "h2",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -1558,7 +1506,7 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper 1.5.0",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -1579,7 +1527,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper 1.5.0",
+ "hyper",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1771,7 +1719,7 @@ dependencies = [
  "futures",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "hyper-util",
  "log",
  "rand",
@@ -1907,7 +1855,7 @@ dependencies = [
  "portable-atomic",
  "postcard",
  "proptest",
- "quic-rpc 0.14.0 (git+https://github.com/n0-computer/quic-rpc.git?branch=naming-bikeshedding)",
+ "quic-rpc",
  "quic-rpc-derive",
  "rand",
  "range-collections",
@@ -1957,7 +1905,7 @@ dependencies = [
  "anyhow",
  "erased_set",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "hyper-util",
  "once_cell",
  "prometheus-client",
@@ -1994,7 +1942,7 @@ dependencies = [
  "hostname",
  "http 1.1.0",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "hyper-util",
  "igd-next",
  "iroh-base",
@@ -3185,9 +3133,8 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d8431b2e7c22929347b61a354d4936d71fe7ab1e6b0475dc50e98276970dfec"
+version = "0.15.0"
+source = "git+https://github.com/n0-computer/quic-rpc.git?branch=map-transports-not-services#16b7c4942365b96fc750627459261e52e1190f6c"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3201,43 +3148,16 @@ dependencies = [
  "serde",
  "slab",
  "tokio",
- "tracing",
-]
-
-[[package]]
-name = "quic-rpc"
-version = "0.14.0"
-source = "git+https://github.com/n0-computer/quic-rpc.git?branch=naming-bikeshedding#067ae4b04bad16036571225904cd6970decb040b"
-dependencies = [
- "anyhow",
- "bincode",
- "bytes",
- "derive_more",
- "educe",
- "flume",
- "futures-lite 2.4.0",
- "futures-sink",
- "futures-util",
- "hex",
- "hyper 0.14.31",
- "iroh-quinn",
- "pin-project",
- "serde",
- "slab",
- "tokio",
- "tokio-serde",
- "tokio-util",
  "tracing",
 ]
 
 [[package]]
 name = "quic-rpc-derive"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "403bc8506c847468e00170dbbbfe2c54d13b090031bcbe474cd3faea021cbd9f"
+version = "0.15.0"
+source = "git+https://github.com/n0-computer/quic-rpc.git?branch=map-transports-not-services#16b7c4942365b96fc750627459261e52e1190f6c"
 dependencies = [
  "proc-macro2",
- "quic-rpc 0.14.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quic-rpc",
  "quote",
  "syn 1.0.109",
 ]
@@ -3509,7 +3429,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.5.0",
+ "hyper",
  "hyper-rustls",
  "hyper-util",
  "ipnet",
@@ -4470,21 +4390,6 @@ dependencies = [
  "rustls",
  "rustls-pki-types",
  "tokio",
-]
-
-[[package]]
-name = "tokio-serde"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "911a61637386b789af998ee23f50aa30d5fd7edcec8d6d3dedae5e5815205466"
-dependencies = [
- "bincode",
- "bytes",
- "educe",
- "futures-core",
- "futures-sink",
- "pin-project",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,7 +3134,8 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.15.0"
-source = "git+https://github.com/n0-computer/quic-rpc.git?branch=map-transports-not-services#16b7c4942365b96fc750627459261e52e1190f6c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61e131f594054d27d077162815db3b5e9ddd76a28fbb9091b68095971e75c286"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3154,7 +3155,8 @@ dependencies = [
 [[package]]
 name = "quic-rpc-derive"
 version = "0.15.0"
-source = "git+https://github.com/n0-computer/quic-rpc.git?branch=map-transports-not-services#16b7c4942365b96fc750627459261e52e1190f6c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbef4c942978f74ef296ae40d43d4375c9d730b65a582688a358108cfd5c0cf7"
 dependencies = [
  "proc-macro2",
  "quic-rpc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -350,9 +350,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.1.34"
+version = "1.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b9470d453346108f93a59222a9a1a5724db32d0a4727b7ab7ace4b4d822dc9"
+checksum = "0f57c4b4da2a9d619dd035f27316d7a426305b75be93d09e92f2b9229c34feaf"
 dependencies = [
  "shlex",
 ]
@@ -1270,6 +1270,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81fe527a889e1532da5c525686d96d4c2e74cdd345badf8dfef9f6b39dd5f5e8"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "524e8ac6999421f49a846c2d4411f337e53497d8ec55d67753beffa43c5d9205"
@@ -1488,6 +1507,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c08302e8fa335b151b788c775ff56e7a03ae64ff85c548ee820fecb70356e85"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.26",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbff0a806a4728c99295b254c8838933b5b082d75e3cb70c8dab21fdfbcfa9a"
@@ -1495,7 +1538,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "h2",
+ "h2 0.4.6",
  "http 1.1.0",
  "http-body 1.0.1",
  "httparse",
@@ -1515,7 +1558,7 @@ checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
 dependencies = [
  "futures-util",
  "http 1.1.0",
- "hyper",
+ "hyper 1.5.0",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -1536,7 +1579,7 @@ dependencies = [
  "futures-util",
  "http 1.1.0",
  "http-body 1.0.1",
- "hyper",
+ "hyper 1.5.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1728,7 +1771,7 @@ dependencies = [
  "futures",
  "http 1.1.0",
  "http-body-util",
- "hyper",
+ "hyper 1.5.0",
  "hyper-util",
  "log",
  "rand",
@@ -1795,7 +1838,7 @@ checksum = "ddc24109865250148c2e0f3d25d4f0f479571723792d3802153c60922a4fb708"
 [[package]]
 name = "iroh-base"
 version = "0.28.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#b17b1f20b4c5e584e1fa4219ce5e375b37e9dbf1"
+source = "git+https://github.com/n0-computer/iroh?branch=main#0a7a534128bf1234a326fcfba134d878e796c377"
 dependencies = [
  "aead",
  "anyhow",
@@ -1864,7 +1907,7 @@ dependencies = [
  "portable-atomic",
  "postcard",
  "proptest",
- "quic-rpc 0.14.0 (git+https://github.com/n0-computer/quic-rpc.git?branch=map-transports-not-services)",
+ "quic-rpc 0.14.0 (git+https://github.com/n0-computer/quic-rpc.git?branch=naming-bikeshedding)",
  "quic-rpc-derive",
  "rand",
  "range-collections",
@@ -1909,12 +1952,12 @@ dependencies = [
 [[package]]
 name = "iroh-metrics"
 version = "0.28.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#b17b1f20b4c5e584e1fa4219ce5e375b37e9dbf1"
+source = "git+https://github.com/n0-computer/iroh?branch=main#0a7a534128bf1234a326fcfba134d878e796c377"
 dependencies = [
  "anyhow",
  "erased_set",
  "http-body-util",
- "hyper",
+ "hyper 1.5.0",
  "hyper-util",
  "once_cell",
  "prometheus-client",
@@ -1929,7 +1972,7 @@ dependencies = [
 [[package]]
 name = "iroh-net"
 version = "0.28.1"
-source = "git+https://github.com/n0-computer/iroh?branch=main#b17b1f20b4c5e584e1fa4219ce5e375b37e9dbf1"
+source = "git+https://github.com/n0-computer/iroh?branch=main#0a7a534128bf1234a326fcfba134d878e796c377"
 dependencies = [
  "anyhow",
  "backoff",
@@ -1951,7 +1994,7 @@ dependencies = [
  "hostname",
  "http 1.1.0",
  "http-body-util",
- "hyper",
+ "hyper 1.5.0",
  "hyper-util",
  "igd-next",
  "iroh-base",
@@ -2056,7 +2099,7 @@ dependencies = [
 [[package]]
 name = "iroh-router"
 version = "0.28.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#b17b1f20b4c5e584e1fa4219ce5e375b37e9dbf1"
+source = "git+https://github.com/n0-computer/iroh?branch=main#0a7a534128bf1234a326fcfba134d878e796c377"
 dependencies = [
  "anyhow",
  "futures-buffered",
@@ -2396,7 +2439,7 @@ dependencies = [
 [[package]]
 name = "netwatch"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#b17b1f20b4c5e584e1fa4219ce5e375b37e9dbf1"
+source = "git+https://github.com/n0-computer/iroh?branch=main#0a7a534128bf1234a326fcfba134d878e796c377"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2915,7 +2958,7 @@ checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 [[package]]
 name = "portmapper"
 version = "0.1.0"
-source = "git+https://github.com/n0-computer/iroh?branch=main#b17b1f20b4c5e584e1fa4219ce5e375b37e9dbf1"
+source = "git+https://github.com/n0-computer/iroh?branch=main#0a7a534128bf1234a326fcfba134d878e796c377"
 dependencies = [
  "anyhow",
  "base64",
@@ -3164,10 +3207,11 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.14.0"
-source = "git+https://github.com/n0-computer/quic-rpc.git?branch=map-transports-not-services#03f97ab0bc5287f873970984d783320350ad3d8a"
+source = "git+https://github.com/n0-computer/quic-rpc.git?branch=naming-bikeshedding#067ae4b04bad16036571225904cd6970decb040b"
 dependencies = [
  "anyhow",
  "bincode",
+ "bytes",
  "derive_more",
  "educe",
  "flume",
@@ -3175,6 +3219,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "hex",
+ "hyper 0.14.31",
  "iroh-quinn",
  "pin-project",
  "serde",
@@ -3240,9 +3285,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-udp"
-version = "0.5.6"
+version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e346e016eacfff12233c243718197ca12f148c84e1e84268a896699b41c71780"
+checksum = "7d5a626c6807713b15cac82a6acaccd6043c9a5408c24baae07611fec3f243da"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -3464,7 +3509,7 @@ dependencies = [
  "http 1.1.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.5.0",
  "hyper-rustls",
  "hyper-util",
  "ipnet",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ parking_lot = { version = "0.12.1", optional = true }
 pin-project = "1.1.5"
 portable-atomic = { version = "1", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
-quic-rpc = { version = "0.13.0", optional = true }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "map-transports-not-services", optional = true }
 quic-rpc-derive = { version = "0.13.0", optional = true }
 quinn = { package = "iroh-quinn", version = "0.11", features = ["ring"] }
 rand = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,8 @@ pin-project = "1.1.5"
 portable-atomic = { version = "1", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 quinn = { package = "iroh-quinn", version = "0.12", features = ["ring"] }
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "naming-bikeshedding", optional = true }
-quic-rpc-derive = { version = "0.14", optional = true }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "map-transports-not-services", optional = true }
+quic-rpc-derive = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "map-transports-not-services", optional = true }
 rand = "0.8"
 range-collections = "0.4.0"
 redb = { version = "2.0.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ parking_lot = { version = "0.12.1", optional = true }
 pin-project = "1.1.5"
 portable-atomic = { version = "1", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "map-transports-not-services", optional = true }
-quic-rpc-derive = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "map-transports-not-services", optional = true }
+quic-rpc = { version = "0.15.0", optional = true }
+quic-rpc-derive = { version = "0.15.0", optional = true }
 quinn = { package = "iroh-quinn", version = "0.12", features = ["ring"] }
 rand = "0.8"
 range-collections = "0.4.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ pin-project = "1.1.5"
 portable-atomic = { version = "1", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
 quinn = { package = "iroh-quinn", version = "0.12", features = ["ring"] }
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "map-transports-not-services", optional = true }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc.git", branch = "naming-bikeshedding", optional = true }
 quic-rpc-derive = { version = "0.14", optional = true }
 rand = "0.8"
 range-collections = "0.4.0"

--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,7 @@ allow = [
       "Unicode-DFS-2016",
       "Zlib",
       "MPL-2.0", # https://fossa.com/blog/open-source-software-licenses-101-mozilla-public-license-2-0/
+      "Unicode-3.0"
 ]
 
 [[licenses.clarify]]

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -25,12 +25,10 @@ use proto::{
         CreateCollectionRequest, CreateCollectionResponse, DeleteRequest, DownloadResponse,
         ExportRequest, ExportResponse, ListIncompleteRequest, ListRequest, ReadAtRequest,
         ReadAtResponse, ValidateRequest,
-    },
-    tags::{
+    }, tags::{
         CreateRequest as TagsCreateRequest, DeleteRequest as TagDeleteRequest,
         ListRequest as TagListRequest, SetRequest as TagsSetRequest, SyncMode,
-    },
-    RpcError, RpcResult, RpcService,
+    }, Request, RpcError, RpcResult, RpcService
 };
 use quic_rpc::server::{RpcChannel, RpcServerError};
 
@@ -59,13 +57,13 @@ impl<D: crate::store::Store> Blobs<D> {
     /// Handle an RPC request
     pub async fn handle_rpc_request<C>(
         self: Arc<Self>,
-        msg: crate::rpc::proto::Request,
+        msg: Request,
         chan: RpcChannel<RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
         C: quic_rpc::ServiceEndpoint<RpcService>,
     {
-        use crate::rpc::proto::Request::*;
+        use Request::*;
         match msg {
             Blobs(msg) => self.handle_blobs_request(msg, chan).await,
             Tags(msg) => self.handle_tags_request(msg, chan).await,

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -57,14 +57,13 @@ const RPC_BLOB_GET_CHANNEL_CAP: usize = 2;
 
 impl<D: crate::store::Store> Blobs<D> {
     /// Handle an RPC request
-    pub async fn handle_rpc_request<S, C>(
+    pub async fn handle_rpc_request<C>(
         self: Arc<Self>,
         msg: crate::rpc::proto::Request,
-        chan: RpcChannel<crate::rpc::proto::RpcService, C, S>,
+        chan: RpcChannel<crate::rpc::proto::RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        S: quic_rpc::Service,
-        C: quic_rpc::ServiceEndpoint<S>,
+        C: quic_rpc::ServiceEndpoint<crate::rpc::proto::RpcService>,
     {
         use crate::rpc::proto::Request::*;
         match msg {
@@ -74,14 +73,13 @@ impl<D: crate::store::Store> Blobs<D> {
     }
 
     /// Handle a tags request
-    pub async fn handle_tags_request<S, C>(
+    pub async fn handle_tags_request<C>(
         self: Arc<Self>,
         msg: proto::tags::Request,
-        chan: RpcChannel<proto::RpcService, C, S>,
+        chan: RpcChannel<proto::RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        S: quic_rpc::Service,
-        C: quic_rpc::ServiceEndpoint<S>,
+        C: quic_rpc::ServiceEndpoint<proto::RpcService>,
     {
         use proto::tags::Request::*;
         match msg {
@@ -93,14 +91,13 @@ impl<D: crate::store::Store> Blobs<D> {
     }
 
     /// Handle a blobs request
-    pub async fn handle_blobs_request<Sv, C>(
+    pub async fn handle_blobs_request<C>(
         self: Arc<Self>,
         msg: proto::blobs::Request,
-        chan: RpcChannel<proto::RpcService, C, Sv>,
+        chan: RpcChannel<proto::RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        Sv: quic_rpc::Service,
-        C: quic_rpc::ServiceEndpoint<Sv>,
+        C: quic_rpc::ServiceEndpoint<proto::RpcService>,
     {
         use proto::blobs::Request::*;
         match msg {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -32,7 +32,7 @@ use proto::{
     },
     Request, RpcError, RpcResult, RpcService,
 };
-use quic_rpc::server::{RpcChannel, RpcServerError};
+use quic_rpc::server::{ChannelTypes, RpcChannel, RpcServerError};
 
 use crate::{
     export::ExportProgress,
@@ -63,7 +63,7 @@ impl<D: crate::store::Store> Blobs<D> {
         chan: RpcChannel<RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        C: quic_rpc::ListenerTypes<RpcService>,
+        C: ChannelTypes<RpcService>,
     {
         use Request::*;
         match msg {
@@ -79,7 +79,7 @@ impl<D: crate::store::Store> Blobs<D> {
         chan: RpcChannel<proto::RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        C: quic_rpc::ListenerTypes<proto::RpcService>,
+        C: ChannelTypes<proto::RpcService>,
     {
         use proto::tags::Request::*;
         match msg {
@@ -97,7 +97,7 @@ impl<D: crate::store::Store> Blobs<D> {
         chan: RpcChannel<proto::RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        C: quic_rpc::ListenerTypes<proto::RpcService>,
+        C: ChannelTypes<proto::RpcService>,
     {
         use proto::blobs::Request::*;
         match msg {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -30,7 +30,7 @@ use proto::{
         CreateRequest as TagsCreateRequest, DeleteRequest as TagDeleteRequest,
         ListRequest as TagListRequest, SetRequest as TagsSetRequest, SyncMode,
     },
-    RpcError, RpcResult,
+    RpcError, RpcResult, RpcService,
 };
 use quic_rpc::server::{RpcChannel, RpcServerError};
 
@@ -60,10 +60,10 @@ impl<D: crate::store::Store> Blobs<D> {
     pub async fn handle_rpc_request<C>(
         self: Arc<Self>,
         msg: crate::rpc::proto::Request,
-        chan: RpcChannel<crate::rpc::proto::RpcService, C>,
+        chan: RpcChannel<RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        C: quic_rpc::ServiceEndpoint<crate::rpc::proto::RpcService>,
+        C: quic_rpc::ServiceEndpoint<RpcService>,
     {
         use crate::rpc::proto::Request::*;
         match msg {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -63,7 +63,7 @@ impl<D: crate::store::Store> Blobs<D> {
         chan: RpcChannel<RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        C: quic_rpc::ServiceEndpoint<RpcService>,
+        C: quic_rpc::ServiceChannel<RpcService>,
     {
         use Request::*;
         match msg {
@@ -79,7 +79,7 @@ impl<D: crate::store::Store> Blobs<D> {
         chan: RpcChannel<proto::RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        C: quic_rpc::ServiceEndpoint<proto::RpcService>,
+        C: quic_rpc::ServiceChannel<proto::RpcService>,
     {
         use proto::tags::Request::*;
         match msg {
@@ -97,7 +97,7 @@ impl<D: crate::store::Store> Blobs<D> {
         chan: RpcChannel<proto::RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        C: quic_rpc::ServiceEndpoint<proto::RpcService>,
+        C: quic_rpc::ServiceChannel<proto::RpcService>,
     {
         use proto::blobs::Request::*;
         match msg {

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -25,10 +25,12 @@ use proto::{
         CreateCollectionRequest, CreateCollectionResponse, DeleteRequest, DownloadResponse,
         ExportRequest, ExportResponse, ListIncompleteRequest, ListRequest, ReadAtRequest,
         ReadAtResponse, ValidateRequest,
-    }, tags::{
+    },
+    tags::{
         CreateRequest as TagsCreateRequest, DeleteRequest as TagDeleteRequest,
         ListRequest as TagListRequest, SetRequest as TagsSetRequest, SyncMode,
-    }, Request, RpcError, RpcResult, RpcService
+    },
+    Request, RpcError, RpcResult, RpcService,
 };
 use quic_rpc::server::{RpcChannel, RpcServerError};
 

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -63,7 +63,7 @@ impl<D: crate::store::Store> Blobs<D> {
         chan: RpcChannel<RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        C: quic_rpc::ServiceChannel<RpcService>,
+        C: quic_rpc::ListenerTypes<RpcService>,
     {
         use Request::*;
         match msg {
@@ -79,7 +79,7 @@ impl<D: crate::store::Store> Blobs<D> {
         chan: RpcChannel<proto::RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        C: quic_rpc::ServiceChannel<proto::RpcService>,
+        C: quic_rpc::ListenerTypes<proto::RpcService>,
     {
         use proto::tags::Request::*;
         match msg {
@@ -97,7 +97,7 @@ impl<D: crate::store::Store> Blobs<D> {
         chan: RpcChannel<proto::RpcService, C>,
     ) -> std::result::Result<(), RpcServerError<C>>
     where
-        C: quic_rpc::ServiceChannel<proto::RpcService>,
+        C: quic_rpc::ListenerTypes<proto::RpcService>,
     {
         use proto::blobs::Request::*;
         match msg {

--- a/src/rpc/client/blobs.rs
+++ b/src/rpc/client/blobs.rs
@@ -1120,8 +1120,7 @@ mod tests {
             let router = router.spawn().await?;
 
             // Setup RPC
-            let (internal_rpc, controller) =
-                quic_rpc::transport::flume::service_connection::<RpcService>(32);
+            let (internal_rpc, controller) = quic_rpc::transport::flume::channel(32);
             let controller = controller.boxed();
             let internal_rpc = internal_rpc.boxed();
             let internal_rpc = quic_rpc::RpcServer::new(internal_rpc);

--- a/src/rpc/client/blobs.rs
+++ b/src/rpc/client/blobs.rs
@@ -995,13 +995,12 @@ mod tests {
         use iroh_net::{NodeAddr, NodeId};
         use tokio_util::task::AbortOnDropHandle;
 
+        use super::RpcService;
         use crate::{
             provider::{CustomEventSender, EventSender},
             rpc::client::{blobs, tags},
             util::local_pool::LocalPool,
         };
-
-        use super::RpcService;
 
         type RpcClient = quic_rpc::RpcClient<RpcService>;
 

--- a/src/rpc/client/blobs.rs
+++ b/src/rpc/client/blobs.rs
@@ -993,7 +993,6 @@ mod tests {
         use std::{path::Path, sync::Arc};
 
         use iroh_net::{NodeAddr, NodeId};
-        use quic_rpc::client::BoxedServiceConnection;
         use tokio_util::task::AbortOnDropHandle;
 
         use crate::{

--- a/src/rpc/client/blobs/batch.rs
+++ b/src/rpc/client/blobs/batch.rs
@@ -9,7 +9,7 @@ use bytes::Bytes;
 use futures_buffered::BufferedStreamExt;
 use futures_lite::StreamExt;
 use futures_util::{sink::Buffer, FutureExt, SinkExt, Stream};
-use quic_rpc::{client::UpdateSink, RpcClient, ServiceConnection};
+use quic_rpc::{client::UpdateSink, Connector, RpcClient};
 use tokio::io::AsyncRead;
 use tokio_util::io::ReaderStream;
 use tracing::{debug, warn};
@@ -36,7 +36,7 @@ use crate::{
 #[derive(derive_more::Debug)]
 struct BatchInner<C>
 where
-    C: ServiceConnection<RpcService>,
+    C: Connector<RpcService>,
 {
     /// The id of the scope.
     batch: BatchId,
@@ -56,11 +56,11 @@ where
 #[derive(derive_more::Debug)]
 pub struct Batch<C>(Arc<BatchInner<C>>)
 where
-    C: ServiceConnection<RpcService>;
+    C: Connector<RpcService>;
 
 impl<C> TagDrop for BatchInner<C>
 where
-    C: ServiceConnection<RpcService>,
+    C: Connector<RpcService>,
 {
     fn on_drop(&self, content: &HashAndFormat) {
         let mut updates = self.updates.lock().unwrap();
@@ -130,7 +130,7 @@ impl Default for AddReaderOpts {
 
 impl<C> Batch<C>
 where
-    C: ServiceConnection<RpcService>,
+    C: Connector<RpcService>,
 {
     pub(super) fn new(
         batch: BatchId,

--- a/src/rpc/client/tags.rs
+++ b/src/rpc/client/tags.rs
@@ -12,7 +12,7 @@
 //! [`Client::delete`] can be used to delete a tag.
 use anyhow::Result;
 use futures_lite::{Stream, StreamExt};
-use quic_rpc::{client::BoxedServiceConnection, RpcClient, ServiceConnection};
+use quic_rpc::{client::BoxedConnector, Connector, RpcClient};
 use serde::{Deserialize, Serialize};
 
 use crate::{
@@ -26,13 +26,13 @@ use crate::{
 /// Iroh tags client.
 #[derive(Debug, Clone)]
 #[repr(transparent)]
-pub struct Client<C = BoxedServiceConnection<RpcService>> {
+pub struct Client<C = BoxedConnector<RpcService>> {
     pub(super) rpc: RpcClient<RpcService, C>,
 }
 
 impl<C> Client<C>
 where
-    C: ServiceConnection<RpcService>,
+    C: Connector<RpcService>,
 {
     /// Creates a new client
     pub fn new(rpc: RpcClient<RpcService, C>) -> Self {

--- a/src/rpc/client/tags.rs
+++ b/src/rpc/client/tags.rs
@@ -12,27 +12,30 @@
 //! [`Client::delete`] can be used to delete a tag.
 use anyhow::Result;
 use futures_lite::{Stream, StreamExt};
-use quic_rpc::{client::BoxedServiceConnection, RpcClient};
+use quic_rpc::{client::BoxedServiceConnection, RpcClient, ServiceConnection};
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    rpc::proto::tags::{DeleteRequest, ListRequest},
+    rpc::proto::{
+        tags::{DeleteRequest, ListRequest},
+        RpcService,
+    },
     BlobFormat, Hash, Tag,
 };
 
 /// Iroh tags client.
 #[derive(Debug, Clone)]
 #[repr(transparent)]
-pub struct Client<C = BoxedServiceConnection<crate::rpc::proto::RpcService>> {
-    pub(super) rpc: RpcClient<crate::rpc::proto::RpcService, C>,
+pub struct Client<C = BoxedServiceConnection<RpcService>> {
+    pub(super) rpc: RpcClient<RpcService, C>,
 }
 
 impl<C> Client<C>
 where
-    C: quic_rpc::ServiceConnection<crate::rpc::proto::RpcService>,
+    C: ServiceConnection<RpcService>,
 {
     /// Creates a new client
-    pub fn new(rpc: RpcClient<crate::rpc::proto::RpcService, C>) -> Self {
+    pub fn new(rpc: RpcClient<RpcService, C>) -> Self {
         Self { rpc }
     }
 

--- a/src/rpc/client/tags.rs
+++ b/src/rpc/client/tags.rs
@@ -23,20 +23,16 @@ use crate::{
 /// Iroh tags client.
 #[derive(Debug, Clone)]
 #[repr(transparent)]
-pub struct Client<
-    C = BoxedServiceConnection<crate::rpc::proto::RpcService>,
-    S = crate::rpc::proto::RpcService,
-> {
-    pub(super) rpc: RpcClient<crate::rpc::proto::RpcService, C, S>,
+pub struct Client<C = BoxedServiceConnection<crate::rpc::proto::RpcService>> {
+    pub(super) rpc: RpcClient<crate::rpc::proto::RpcService, C>,
 }
 
-impl<C, S> Client<C, S>
+impl<C> Client<C>
 where
-    C: quic_rpc::ServiceConnection<S>,
-    S: quic_rpc::Service,
+    C: quic_rpc::ServiceConnection<crate::rpc::proto::RpcService>,
 {
     /// Creates a new client
-    pub fn new(rpc: RpcClient<crate::rpc::proto::RpcService, C, S>) -> Self {
+    pub fn new(rpc: RpcClient<crate::rpc::proto::RpcService, C>) -> Self {
         Self { rpc }
     }
 


### PR DESCRIPTION
## Description

Try out the new simplified service mapping

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
