### PR TITLE
feat: Add a lazily initialized in mem client for ffi etc.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3134,8 +3134,7 @@ dependencies = [
 [[package]]
 name = "quic-rpc"
 version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61e131f594054d27d077162815db3b5e9ddd76a28fbb9091b68095971e75c286"
+source = "git+https://github.com/n0-computer/quic-rpc?branch=main#32d5bc1a08609f4f0b5650980088f07d81971a55"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -3149,6 +3148,7 @@ dependencies = [
  "serde",
  "slab",
  "tokio",
+ "tokio-util",
  "tracing",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3133,8 +3133,9 @@ dependencies = [
 
 [[package]]
 name = "quic-rpc"
-version = "0.15.0"
-source = "git+https://github.com/n0-computer/quic-rpc?branch=main#32d5bc1a08609f4f0b5650980088f07d81971a55"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc623a188942fc875926f7baeb2cb08ed4288b64f29072656eb051e360ee7623"
 dependencies = [
  "anyhow",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ parking_lot = { version = "0.12.1", optional = true }
 pin-project = "1.1.5"
 portable-atomic = { version = "1", optional = true }
 postcard = { version = "1", default-features = false, features = ["alloc", "use-std", "experimental-derive"] }
-quic-rpc = { version = "0.15.0", optional = true }
+quic-rpc = { version = "0.15.1", optional = true }
 quic-rpc-derive = { version = "0.15.0", optional = true }
 quinn = { package = "iroh-quinn", version = "0.12", features = ["ring"] }
 rand = "0.8"
@@ -131,4 +131,4 @@ iroh-router = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-net = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-metrics = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-base = { git = "https://github.com/n0-computer/iroh", branch = "main" }
-quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "main" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,3 +131,4 @@ iroh-router = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-net = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-metrics = { git = "https://github.com/n0-computer/iroh", branch = "main" }
 iroh-base = { git = "https://github.com/n0-computer/iroh", branch = "main" }
+quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,7 @@ license-files = [
 [advisories]
 ignore = [
       "RUSTSEC-2024-0370", # unmaintained, no upgrade available
+      "RUSTSEC-2024-0384", # unmaintained, no upgrade available
 ]
 
 [sources]

--- a/src/downloader.rs
+++ b/src/downloader.rs
@@ -645,7 +645,6 @@ impl<G: Getter<Connection = D::Connection>, D: Dialer> Service<G, D> {
     }
 
     /// Handle receiving a [`Message`].
-    ///
     // This is called in the actor loop, and only async because subscribing to an existing transfer
     // sends the initial state.
     async fn handle_message(&mut self, msg: Message) {

--- a/src/net_protocol.rs
+++ b/src/net_protocol.rs
@@ -3,7 +3,10 @@
 // TODO: reduce API surface and add documentation
 #![allow(missing_docs)]
 
-use std::{collections::BTreeMap, sync::Arc};
+use std::{
+    collections::BTreeMap,
+    sync::{Arc, OnceLock},
+};
 
 use anyhow::{anyhow, Result};
 use futures_lite::future::Boxed as BoxedFuture;

--- a/src/net_protocol.rs
+++ b/src/net_protocol.rs
@@ -36,6 +36,8 @@ pub struct Blobs<S> {
     downloader: Downloader,
     batches: tokio::sync::Mutex<BlobBatches>,
     endpoint: Endpoint,
+    #[cfg(feature = "rpc")]
+    pub(crate) rpc_handler: Arc<OnceLock<crate::rpc::RpcHandler>>,
 }
 
 /// Name used for logging when new node addresses are added from gossip.
@@ -107,6 +109,8 @@ impl<S: crate::store::Store> Blobs<S> {
             downloader,
             endpoint,
             batches: Default::default(),
+            #[cfg(feature = "rpc")]
+            rpc_handler: Arc::new(OnceLock::new()),
         }
     }
 

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -148,7 +148,8 @@
 //! # use bao_tree::{ChunkNum, ChunkRanges};
 //! # use iroh_blobs::protocol::{GetRequest, RangeSpecSeq};
 //! # let hash: iroh_blobs::Hash = [0; 32].into();
-//! let ranges = &ChunkRanges::from(..ChunkNum(10)) | &ChunkRanges::from(ChunkNum(100)..ChunkNum(110));
+//! let ranges =
+//!     &ChunkRanges::from(..ChunkNum(10)) | &ChunkRanges::from(ChunkNum(100)..ChunkNum(110));
 //! let spec = RangeSpecSeq::from_ranges([ranges]);
 //! let request = GetRequest::new(hash, spec);
 //! ```
@@ -236,8 +237,8 @@
 //! # use iroh_blobs::protocol::{GetRequest, RangeSpecSeq};
 //! # let hash: iroh_blobs::Hash = [0; 32].into();
 //! let spec = RangeSpecSeq::from_ranges_infinite([
-//!   ChunkRanges::all(), // the collection itself
-//!   ChunkRanges::from(..ChunkNum(1)), // the first chunk of each child
+//!     ChunkRanges::all(),               // the collection itself
+//!     ChunkRanges::from(..ChunkNum(1)), // the first chunk of each child
 //! ]);
 //! let request = GetRequest::new(hash, spec);
 //! ```
@@ -252,9 +253,9 @@
 //! # use iroh_blobs::protocol::{GetRequest, RangeSpecSeq};
 //! # let hash: iroh_blobs::Hash = [0; 32].into();
 //! let spec = RangeSpecSeq::from_ranges([
-//!   ChunkRanges::empty(), // we don't need the collection itself
-//!   ChunkRanges::empty(), // we don't need the first child either
-//!   ChunkRanges::all(), // we need the second child completely
+//!     ChunkRanges::empty(), // we don't need the collection itself
+//!     ChunkRanges::empty(), // we don't need the first child either
+//!     ChunkRanges::all(),   // we need the second child completely
 //! ]);
 //! let request = GetRequest::new(hash, spec);
 //! ```

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -62,7 +62,7 @@ const RPC_BLOB_GET_CHANNEL_CAP: usize = 2;
 
 impl<D: crate::store::Store> Blobs<D> {
     /// Get a client for the blobs protocol
-    pub fn client(self: Arc<Self>) -> blobs::Client<MemConnector> {
+    pub fn client(self: Arc<Self>) -> blobs::MemClient {
         let client = self
             .rpc_handler
             .get_or_init(|| RpcHandler::new(&self))

--- a/src/rpc/client.rs
+++ b/src/rpc/client.rs
@@ -1,9 +1,14 @@
 //! Iroh blobs and tags client
 use anyhow::Result;
 use futures_util::{Stream, StreamExt};
+use quic_rpc::transport::flume::FlumeConnector;
 
 pub mod blobs;
 pub mod tags;
+
+/// Type alias for a memory-backed client.
+pub(crate) type MemConnector =
+    FlumeConnector<crate::rpc::proto::Response, crate::rpc::proto::Request>;
 
 fn flatten<T, E1, E2>(
     s: impl Stream<Item = Result<Result<T, E1>, E2>>,

--- a/src/rpc/client/blobs.rs
+++ b/src/rpc/client/blobs.rs
@@ -120,6 +120,11 @@ where
         Self { rpc }
     }
 
+    /// Get a tags client.
+    pub fn tags(&self) -> tags::Client<C> {
+        tags::Client::new(self.rpc.clone())
+    }
+
     /// Check if a blob is completely stored on the node.
     ///
     /// Note that this will return false for blobs that are partially stored on

--- a/src/rpc/client/blobs.rs
+++ b/src/rpc/client/blobs.rs
@@ -111,6 +111,9 @@ pub struct Client<C = BoxedConnector<RpcService>> {
     pub(super) rpc: RpcClient<RpcService, C>,
 }
 
+/// Type alias for a memory-backed client.
+pub type MemClient = Client<crate::rpc::MemConnector>;
+
 impl<C> Client<C>
 where
     C: Connector<RpcService>,

--- a/src/util/fs.rs
+++ b/src/util/fs.rs
@@ -179,7 +179,6 @@ pub struct PathContent {
 }
 
 /// Walks the directory to get the total size and number of files in directory or file
-///
 // TODO: possible combine with `scan_dir`
 pub fn path_content_info(path: impl AsRef<Path>) -> anyhow::Result<PathContent> {
     path_content_info0(path)


### PR DESCRIPTION
## Description

Add a mem rpc client just like in https://github.com/n0-computer/iroh-gossip/pull/7

Also make it possible to get tags from blobs so blobs is the "entry point" of the blobs client api.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
