### PR TITLE
feat: Pluggable gc with exemptions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3963,9 +3963,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.17"
+version = "0.23.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f1a745511c54ba6d4465e8d5dfbd81b45791756de28d4981af70d6dca128f1e"
+checksum = "9c9cc1d47e243d655ace55ed38201c19ae02c148ae56412ab8750e8f0166ab7f"
 dependencies = [
  "log",
  "once_cell",

--- a/src/net_protocol.rs
+++ b/src/net_protocol.rs
@@ -41,7 +41,7 @@ pub type ProtectCb = Box<dyn Fn(&mut BTreeSet<Hash>) -> BoxFuture<()> + Send + S
 /// The state of the gc loop.
 #[derive(derive_more::Debug)]
 enum GcState {
-    // Gc loop is not yet running. Other protcols can add protect callbacks
+    // Gc loop is not yet running. Other protocols can add protect callbacks
     Initial(#[debug(skip)] Vec<ProtectCb>),
     // Gc loop is running. No more protect callbacks can be added.
     Started(#[allow(dead_code)] Option<local_pool::Run<()>>),

--- a/tests/blobs.rs
+++ b/tests/blobs.rs
@@ -59,8 +59,8 @@ async fn blobs_gc_protected() -> TestResult<()> {
     tokio::time::sleep(Duration::from_millis(100)).await;
     // protected from gc due to tag
     assert!(client.has(h1.hash).await?);
-    client.tags().delete(h1.tag).await?;
     protected.lock().unwrap().push(h1.hash);
+    client.tags().delete(h1.tag).await?;
     tokio::time::sleep(Duration::from_millis(100)).await;
     // protected from gc due to being in protected set
     assert!(client.has(h1.hash).await?);

--- a/tests/blobs.rs
+++ b/tests/blobs.rs
@@ -4,7 +4,7 @@ use std::{
     time::Duration,
 };
 
-use iroh_blobs::{net_protocol::Blobs, store::GcConfig, util::local_pool::LocalPool, Hash};
+use iroh_blobs::{net_protocol::Blobs, store::GcConfig, util::local_pool::LocalPool};
 use iroh_net::Endpoint;
 use testresult::TestResult;
 
@@ -39,6 +39,7 @@ async fn blobs_gc_protected() -> TestResult<()> {
         >,
     > = blobs.clone().client();
     let h1 = client.add_bytes(b"test".to_vec()).await?;
+    let protected = Arc::new(Mutex::new(Vec::new()));
     blobs.add_protected(Box::new({
         let protected = protected.clone();
         move |x| {

--- a/tests/blobs.rs
+++ b/tests/blobs.rs
@@ -1,0 +1,70 @@
+#![cfg(feature = "net_protocol")]
+use std::{
+    sync::{Arc, Mutex},
+    time::Duration,
+};
+
+use iroh_blobs::{net_protocol::Blobs, store::GcConfig, util::local_pool::LocalPool, Hash};
+use iroh_net::Endpoint;
+use testresult::TestResult;
+
+#[tokio::test]
+async fn blobs_gc_smoke() -> TestResult<()> {
+    let pool = LocalPool::default();
+    let endpoint = Endpoint::builder().bind().await?;
+    let blobs = Blobs::memory().build(pool.handle(), &endpoint);
+    let client = blobs.clone().client();
+    blobs.start_gc(GcConfig {
+        period: Duration::from_millis(1),
+        done_callback: None,
+    })?;
+    let h1 = client.add_bytes(b"test".to_vec()).await?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(client.has(h1.hash).await?);
+    client.tags().delete(h1.tag).await?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    assert!(!client.has(h1.hash).await?);
+    Ok(())
+}
+
+#[tokio::test]
+async fn blobs_gc_protected() -> TestResult<()> {
+    let pool = LocalPool::default();
+    let endpoint = Endpoint::builder().bind().await?;
+    let blobs = Blobs::memory().build(pool.handle(), &endpoint);
+    let client: iroh_blobs::rpc::client::blobs::Client<
+        quic_rpc::transport::flume::FlumeConnector<
+            iroh_blobs::rpc::proto::Response,
+            iroh_blobs::rpc::proto::Request,
+        >,
+    > = blobs.clone().client();
+    let h1 = client.add_bytes(b"test".to_vec()).await?;
+    let protected: Arc<Mutex<Vec<Hash>>> = Arc::new(Mutex::new(Vec::new()));
+    let protected2 = protected.clone();
+    blobs.add_protected(Box::new(move |x| {
+        let protected = protected2.clone();
+        Box::pin(async move {
+            let protected = protected.lock().unwrap();
+            for h in protected.as_slice() {
+                x.insert(*h);
+            }
+        })
+    }))?;
+    blobs.start_gc(GcConfig {
+        period: Duration::from_millis(1),
+        done_callback: None,
+    })?;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // protected from gc due to tag
+    assert!(client.has(h1.hash).await?);
+    client.tags().delete(h1.tag).await?;
+    protected.lock().unwrap().push(h1.hash);
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // protected from gc due to being in protected set
+    assert!(client.has(h1.hash).await?);
+    protected.lock().unwrap().clear();
+    tokio::time::sleep(Duration::from_millis(100)).await;
+    // not protected, must be gone
+    assert!(!client.has(h1.hash).await?);
+    Ok(())
+}


### PR DESCRIPTION
## Description

This adds gc to blobs so it does not have to be driven externally. A big complication is that we want to have the ability to add exemptions to gc, e.g. from docs or willow.

So the gc is initially not running when the Blobs object is created. We have the ability to add exemption callbacks in this stage. Once the setup is done you can (but don't have to!) start the gc loop, at which point adding exemptions is no longer possible.

# Todo:

- [x] try out with docs

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
