### PR TITLE
feat: Add Blobs::builder and use it from Blobs::memory and Blobs::persistent

### DIFF
--- a/src/net_protocol.rs
+++ b/src/net_protocol.rs
@@ -153,14 +153,21 @@ impl<S: crate::store::Store> Builder<S> {
     }
 }
 
-impl Blobs<crate::store::mem::Store> {
-    /// Create a new memory-backed Blobs protocol handler.
-    pub fn memory() -> Builder<crate::store::mem::Store> {
+impl<S> Blobs<S> {
+    /// Create a new Blobs protocol handler builder, given a store.
+    pub fn builder(store: S) -> Builder<S> {
         Builder {
-            store: crate::store::mem::Store::new(),
+            store,
             events: None,
             gc_config: None,
         }
+    }
+}
+
+impl Blobs<crate::store::mem::Store> {
+    /// Create a new memory-backed Blobs protocol handler.
+    pub fn memory() -> Builder<crate::store::mem::Store> {
+        Self::builder(crate::store::mem::Store::new())
     }
 }
 
@@ -169,11 +176,7 @@ impl Blobs<crate::store::fs::Store> {
     pub async fn persistent(
         path: impl AsRef<std::path::Path>,
     ) -> anyhow::Result<Builder<crate::store::fs::Store>> {
-        Ok(Builder {
-            store: crate::store::fs::Store::load(path).await?,
-            events: None,
-            gc_config: None,
-        })
+        Ok(Self::builder(crate::store::fs::Store::load(path).await?))
     }
 }
 

--- a/src/store/fs/tables.rs
+++ b/src/store/fs/tables.rs
@@ -83,8 +83,8 @@ pub(super) struct ReadOnlyTables {
     pub inline_outboard: redb::ReadOnlyTable<Hash, &'static [u8]>,
 }
 
-impl<'txn> ReadOnlyTables {
-    pub fn new(tx: &'txn redb::ReadTransaction) -> std::result::Result<Self, TableError> {
+impl ReadOnlyTables {
+    pub fn new(tx: &redb::ReadTransaction) -> std::result::Result<Self, TableError> {
         Ok(Self {
             blobs: tx.open_table(BLOBS_TABLE)?,
             tags: tx.open_table(TAGS_TABLE)?,


### PR DESCRIPTION
## Description

Add Blobs::builder and use it from Blobs::memory and Blobs::persistent

So we have the ability to use the builder when we have a store from outside.

## Breaking Changes

none

## Notes & open questions

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
