### PR TITLE
feat: allow specifying the tokio runtime to use for the rpc tasks

### DIFF
--- a/src/rpc/client/blobs.rs
+++ b/src/rpc/client/blobs.rs
@@ -1074,6 +1074,7 @@ mod tests {
                     events,
                     downloader,
                     endpoint.clone(),
+                    tokio::runtime::Handle::current(),
                 ));
                 router = router.accept(crate::ALPN, blobs.clone());
 


### PR DESCRIPTION
## Description

Allow specifying the tokio runtime to use for the rpc tasks

With this change, build() will panic if it is not called in a tokio context, unless you have provided a tokio_rt in the builder.

I don't like panicking in build, but it seems that this is idiomatic tokio code, so what can I do?

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
