### PR TITLE
feat! Remove S type parameter

### DIFF
--- a/src/net_protocol.rs
+++ b/src/net_protocol.rs
@@ -194,10 +194,6 @@ impl<S: crate::store::Store> Blobs<S> {
         }
     }
 
-    pub fn store(&self) -> &S {
-        &self.store
-    }
-
     pub fn rt(&self) -> &LocalPoolHandle {
         &self.rt
     }

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -41,7 +41,7 @@ use tokio::io::AsyncReadExt;
 #[derive(Debug)]
 pub struct Node<S> {
     pub router: iroh::protocol::Router,
-    pub blobs: Arc<Blobs<S>>,
+    pub blobs: Arc<Blobs>,
     pub store: S,
     pub _local_pool: LocalPool,
 }


### PR DESCRIPTION
## Description

This removes the `S` type parameter from the `Blobs` protocol handler.

## Breaking Changes

Blobs no longer has the `S` type parameter. As a consequence, `Blobs` can no longer have the store available. So any code that needs direct access to the store can no longer get that via the protocol handler.

- `Blobs<S>` -> `Blobs`
- `Blobs::store` is removed (you need to keep a separate reference to the store)
- `Blobs::handle_rpc_request` removed (you need to create a separate RpcHandler)
- `Blobs::rt` renamed to `Blobs::local_pool_handle`

## Notes & open questions

Rpc requires knowing the type of the store. But Blobs does not have that info. So the way it works now is that you can build a rpc handler using the blobs builder, and then get the blobs protocol handler from that.

Not super nice, but I can't see another way to do this since once the type info is gone there is no way to get it back.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
