### PR TITLE
feat!: Make blobs more cheaply cloneable by by giving it an Inner

### DIFF
--- a/examples/custom-protocol.rs
+++ b/examples/custom-protocol.rs
@@ -91,7 +91,7 @@ async fn main() -> Result<()> {
     let local_pool = LocalPool::default();
     let blobs = Blobs::memory().build(local_pool.handle(), builder.endpoint());
     let builder = builder.accept(iroh_blobs::ALPN, blobs.clone());
-    let blobs_client = blobs.client();
+    let blobs_client = blobs.spawn_rpc();
 
     // Build our custom protocol handler. The `builder` exposes access to various subsystems in the
     // iroh node. In our case, we need a blobs client and the endpoint.

--- a/examples/hello-world-fetch.rs
+++ b/examples/hello-world-fetch.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
     let blobs = Blobs::memory().build(local_pool.handle(), builder.endpoint());
     let builder = builder.accept(iroh_blobs::ALPN, blobs.clone());
     let node = builder.spawn().await?;
-    let blobs_client = blobs.client();
+    let blobs_client = blobs.spawn_rpc();
 
     println!("fetching hash:  {}", ticket.hash());
     println!("node id:        {}", node.endpoint().node_id());

--- a/examples/hello-world-provide.rs
+++ b/examples/hello-world-provide.rs
@@ -28,7 +28,7 @@ async fn main() -> anyhow::Result<()> {
     let local_pool = LocalPool::default();
     let blobs = Blobs::memory().build(local_pool.handle(), builder.endpoint());
     let builder = builder.accept(iroh_blobs::ALPN, blobs.clone());
-    let blobs_client = blobs.client();
+    let blobs_client = blobs.spawn_rpc();
     let node = builder.spawn().await?;
 
     // add some data and remember the hash

--- a/examples/local-swarm-discovery.rs
+++ b/examples/local-swarm-discovery.rs
@@ -78,7 +78,7 @@ async fn main() -> anyhow::Result<()> {
     let blobs = Blobs::memory().build(local_pool.handle(), builder.endpoint());
     let builder = builder.accept(iroh_blobs::ALPN, blobs.clone());
     let node = builder.spawn().await?;
-    let blobs_client = blobs.client();
+    let blobs_client = blobs.spawn_rpc();
 
     match &cli.command {
         Commands::Accept { path } => {

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -26,7 +26,7 @@ async fn main() -> Result<()> {
         .spawn()
         .await?;
 
-    let blobs = blobs.client();
+    let blobs = blobs.spawn_rpc();
 
     let args = std::env::args().collect::<Vec<_>>();
     match &args.iter().map(String::as_str).collect::<Vec<_>>()[..] {

--- a/src/net_protocol.rs
+++ b/src/net_protocol.rs
@@ -62,8 +62,6 @@ struct BlobsInner<S> {
 #[derive(Debug, Clone)]
 pub struct Blobs<S> {
     inner: Arc<BlobsInner<S>>,
-    #[cfg(feature = "rpc")]
-    pub(crate) rpc_handler: Arc<std::sync::OnceLock<crate::rpc::RpcHandler>>,
 }
 
 /// Keeps track of all the currently active batch operations of the blobs api.
@@ -193,8 +191,6 @@ impl<S: crate::store::Store> Blobs<S> {
                 batches: Default::default(),
                 gc_state: Default::default(),
             }),
-            #[cfg(feature = "rpc")]
-            rpc_handler: Default::default(),
         }
     }
 

--- a/tests/blobs.rs
+++ b/tests/blobs.rs
@@ -32,12 +32,7 @@ async fn blobs_gc_protected() -> TestResult<()> {
     let pool = LocalPool::default();
     let endpoint = Endpoint::builder().bind().await?;
     let blobs = Blobs::memory().build(pool.handle(), &endpoint);
-    let client: iroh_blobs::rpc::client::blobs::Client<
-        quic_rpc::transport::flume::FlumeConnector<
-            iroh_blobs::rpc::proto::Response,
-            iroh_blobs::rpc::proto::Request,
-        >,
-    > = blobs.clone().client();
+    let client = blobs.clone().client();
     let h1 = client.add_bytes(b"test".to_vec()).await?;
     let protected = Arc::new(Mutex::new(Vec::new()));
     blobs.add_protected(Box::new({

--- a/tests/blobs.rs
+++ b/tests/blobs.rs
@@ -13,7 +13,7 @@ async fn blobs_gc_smoke() -> TestResult<()> {
     let pool = LocalPool::default();
     let endpoint = Endpoint::builder().bind().await?;
     let blobs = Blobs::memory().build(pool.handle(), &endpoint);
-    let client = blobs.clone().client();
+    let client = blobs.spawn_rpc();
     blobs.start_gc(GcConfig {
         period: Duration::from_millis(1),
         done_callback: None,
@@ -32,7 +32,7 @@ async fn blobs_gc_protected() -> TestResult<()> {
     let pool = LocalPool::default();
     let endpoint = Endpoint::builder().bind().await?;
     let blobs = Blobs::memory().build(pool.handle(), &endpoint);
-    let client = blobs.clone().client();
+    let client = blobs.spawn_rpc();
     let h1 = client.add_bytes(b"test".to_vec()).await?;
     let protected = Arc::new(Mutex::new(Vec::new()));
     blobs.add_protected(Box::new({

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -20,7 +20,7 @@ use iroh::{protocol::Router, Endpoint, NodeAddr, NodeId};
 use iroh_blobs::{
     hashseq::HashSeq,
     net_protocol::Blobs,
-    rpc::client::{blobs, tags},
+    rpc::{client::tags, RpcHandler},
     store::{
         bao_tree, BaoBatchWriter, ConsistencyCheckProgress, EntryStatus, GcConfig, MapEntryMut,
         MapMut, ReportLevel, Store,
@@ -66,8 +66,8 @@ impl<S: Store> Node<S> {
     }
 
     /// Returns an in-memory blobs client
-    pub fn blobs(&self) -> blobs::MemClient {
-        self.blobs.clone().client()
+    pub fn blobs(&self) -> RpcHandler {
+        self.blobs.client()
     }
 
     /// Returns an in-memory tags client

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -67,7 +67,7 @@ impl<S: Store> Node<S> {
 
     /// Returns an in-memory blobs client
     pub fn blobs(&self) -> RpcHandler {
-        self.blobs.client()
+        self.blobs.spawn_rpc()
     }
 
     /// Returns an in-memory tags client


### PR DESCRIPTION
## Description

Make blobs more cheaply cloneable by by giving it an Inner

Instead of having lots of Arcs in Blobs, introduce a BlobsInner and arc the whole thing. This makes cloning Blobs much cheaper and also simplifies the code a bit.

Also remove the lazily initialized rpc client/rpc handler pair and instead provide a fn to return that handler for the API user to store somewhere.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

How should the fn be called that returns the rpc handler. Probably best to rename it since just changing .client() to return an owned thing instead of a borrowed thing would result in people using it in a wrong way (create it on demand on each call, for example).

`create_client()`?
`create_handler()`?

Likewise we now need a name for the thing that is returned. People want to store it somewhere, so it can't just be an impl Deref<MemClient>.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
