### PR TITLE
chore: Update rcgen to 0.13

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2029,7 +2029,7 @@ dependencies = [
  "portmapper",
  "postcard",
  "rand",
- "rcgen 0.13.1",
+ "rcgen",
  "reqwest",
  "ring",
  "rtnetlink 0.13.1",
@@ -2138,7 +2138,7 @@ dependencies = [
  "quic-rpc-derive",
  "rand",
  "range-collections",
- "rcgen 0.12.1",
+ "rcgen",
  "redb",
  "reflink-copy",
  "rustls",
@@ -2305,7 +2305,7 @@ dependencies = [
  "pin-project",
  "postcard",
  "rand",
- "rcgen 0.13.1",
+ "rcgen",
  "regex",
  "reqwest",
  "ring",
@@ -3624,18 +3624,6 @@ dependencies = [
 
 [[package]]
 name = "rcgen"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48406db8ac1f3cbc7dcdb56ec355343817958a356ff430259bb07baf7607e1e1"
-dependencies = [
- "pem",
- "ring",
- "time",
- "yasna",
-]
-
-[[package]]
-name = "rcgen"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54077e1872c46788540de1ea3d7f4ccb1983d12f9aa909b234468676c1a36779"
@@ -4820,7 +4808,7 @@ dependencies = [
  "num-bigint",
  "pem",
  "proc-macro2",
- "rcgen 0.13.1",
+ "rcgen",
  "reqwest",
  "ring",
  "rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,7 @@ serde_test = "1.0.176"
 testresult = "0.4.0"
 tokio = { version = "1", features = ["macros", "test-util"] }
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-rcgen = "0.12"
+rcgen = "0.13"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tempfile = "3.10.0"
 futures-util = "0.3.30"

--- a/examples/connect/mod.rs
+++ b/examples/connect/mod.rs
@@ -53,10 +53,7 @@ pub async fn make_and_write_certs() -> Result<(
         .await
         .context("failed to write private key")?;
 
-    Ok((
-        rustls::pki_types::PrivateKeyDer::try_from(key).unwrap(),
-        rustls::pki_types::CertificateDer::from(cert),
-    ))
+    Ok((rustls::pki_types::PrivateKeyDer::from(key), cert))
 }
 
 // derived from `quinn/examples/client.rs`

--- a/examples/connect/mod.rs
+++ b/examples/connect/mod.rs
@@ -3,6 +3,7 @@ use std::{path::PathBuf, sync::Arc};
 
 use anyhow::{bail, Context, Result};
 use quinn::crypto::rustls::{QuicClientConfig, QuicServerConfig};
+use rustls::pki_types::{CertificateDer, PrivatePkcs8KeyDer};
 use tokio::fs;
 
 pub const EXAMPLE_ALPN: &[u8] = b"n0/iroh/examples/bytes/0";
@@ -40,15 +41,15 @@ pub async fn make_and_write_certs() -> Result<(
     let key_path = path.join("key.der");
     let cert_path = path.join("cert.der");
 
-    let key = cert.serialize_private_key_der();
-    let cert = cert.serialize_der().unwrap();
+    let key = PrivatePkcs8KeyDer::from(cert.key_pair.serialize_der());
+    let cert: CertificateDer = cert.cert.into();
     tokio::fs::create_dir_all(path)
         .await
         .context("failed to create certificate directory")?;
     tokio::fs::write(cert_path, &cert)
         .await
         .context("failed to write certificate")?;
-    tokio::fs::write(key_path, &key)
+    tokio::fs::write(key_path, key.secret_pkcs8_der())
         .await
         .context("failed to write private key")?;
 


### PR DESCRIPTION
## Description

Update rcgen to 0.13 in examples

## Breaking Changes

None

## Notes & open questions

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
