### PR TITLE
feat: Richer tags api

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -256,6 +256,12 @@ pub struct HashAndFormat {
     pub format: BlobFormat,
 }
 
+impl From<Hash> for HashAndFormat {
+    fn from(hash: Hash) -> Self {
+        Self::raw(hash)
+    }
+}
+
 #[cfg(feature = "redb")]
 mod redb_support {
     use postcard::experimental::max_size::MaxSize;

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -313,20 +313,10 @@ impl<D: crate::store::Store> Handler<D> {
         tracing::info!("blob_list_tags");
         let blobs = self;
         Gen::new(|co| async move {
-            let tags = blobs.store().tags().await.unwrap();
+            let tags = blobs.store().tags(msg.from, msg.to).await.unwrap();
             #[allow(clippy::manual_flatten)]
             for item in tags {
                 if let Ok((name, HashAndFormat { hash, format })) = item {
-                    if let Some(from) = msg.from.as_ref() {
-                        if &name < from {
-                            continue;
-                        }
-                    }
-                    if let Some(to) = msg.to.as_ref() {
-                        if &name >= to {
-                            break;
-                        }
-                    }
                     if (format.is_raw() && msg.raw) || (format.is_hash_seq() && msg.hash_seq) {
                         co.yield_(TagInfo { name, hash, format }).await;
                     }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -317,6 +317,16 @@ impl<D: crate::store::Store> Handler<D> {
             #[allow(clippy::manual_flatten)]
             for item in tags {
                 if let Ok((name, HashAndFormat { hash, format })) = item {
+                    if let Some(from) = msg.from.as_ref() {
+                        if &name < from {
+                            continue;
+                        }
+                    }
+                    if let Some(to) = msg.to.as_ref() {
+                        if &name >= to {
+                            break;
+                        }
+                    }
                     if (format.is_raw() && msg.raw) || (format.is_hash_seq() && msg.hash_seq) {
                         co.yield_(TagInfo { name, hash, format }).await;
                     }

--- a/src/rpc/client/blobs/batch.rs
+++ b/src/rpc/client/blobs/batch.rs
@@ -441,7 +441,7 @@ where
             .rpc
             .rpc(tags::SetRequest {
                 name: tag,
-                value: Some(tt.hash_and_format()),
+                value: tt.hash_and_format(),
                 batch: Some(self.0.batch),
                 sync: SyncMode::Full,
             })

--- a/src/rpc/client/tags.rs
+++ b/src/rpc/client/tags.rs
@@ -270,7 +270,7 @@ where
         self.delete_with_opts(DeleteOptions::range(range)).await
     }
 
-    /// Lists all tags with the given prefix.
+    /// Delete all tags with the given prefix.
     pub async fn delete_prefix(&self, prefix: impl AsRef<[u8]>) -> Result<()> {
         self.delete_with_opts(DeleteOptions::prefix(prefix.as_ref()))
             .await

--- a/src/rpc/client/tags.rs
+++ b/src/rpc/client/tags.rs
@@ -289,6 +289,15 @@ where
         self.delete_with_opts(DeleteOptions::prefix(prefix.as_ref()))
             .await
     }
+
+    /// Delete all tags. Use with care. After this, all data will be garbage collected.
+    pub async fn delete_all(&self) -> Result<()> {
+        self.delete_with_opts(DeleteOptions {
+            from: None,
+            to: None,
+        })
+        .await
+    }
 }
 
 /// Information about a tag.
@@ -303,6 +312,17 @@ pub struct TagInfo {
 }
 
 impl TagInfo {
+    /// Create a new tag info.
+    pub fn new(name: impl AsRef<[u8]>, value: impl Into<HashAndFormat>) -> Self {
+        let name = name.as_ref();
+        let value = value.into();
+        Self {
+            name: Tag::from(name),
+            hash: value.hash,
+            format: value.format,
+        }
+    }
+
     /// Get the hash and format of the tag.
     pub fn hash_and_format(&self) -> HashAndFormat {
         HashAndFormat {

--- a/src/rpc/client/tags.rs
+++ b/src/rpc/client/tags.rs
@@ -42,6 +42,12 @@ where
         Self { rpc }
     }
 
+    /// Get the value of a single tag
+    pub async fn get(&self, name: Tag) -> Result<Option<TagInfo>> {
+        let mut stream = self.rpc.server_streaming(ListRequest::single(name)).await?;
+        Ok(stream.next().await.transpose()?)
+    }
+
     /// Lists all tags.
     pub async fn list(&self) -> Result<impl Stream<Item = Result<TagInfo>>> {
         let stream = self.rpc.server_streaming(ListRequest::all()).await?;

--- a/src/rpc/client/tags.rs
+++ b/src/rpc/client/tags.rs
@@ -143,6 +143,7 @@ pub struct DeleteOptions {
 }
 
 impl DeleteOptions {
+    /// Delete a single tag
     pub fn single(name: Tag) -> Self {
         Self {
             to: Some(name.successor()),

--- a/src/rpc/client/tags.rs
+++ b/src/rpc/client/tags.rs
@@ -10,6 +10,8 @@
 //! [`Client::list_hash_seq`] can be used to list all tags with a hash_seq format.
 //!
 //! [`Client::delete`] can be used to delete a tag.
+use std::ops::{Bound, RangeBounds};
+
 use anyhow::Result;
 use futures_lite::{Stream, StreamExt};
 use quic_rpc::{client::BoxedConnector, Connector, RpcClient};
@@ -30,6 +32,125 @@ pub struct Client<C = BoxedConnector<RpcService>> {
     pub(super) rpc: RpcClient<RpcService, C>,
 }
 
+/// Options for a list operation.
+#[derive(Debug, Clone)]
+pub struct ListOptions {
+    /// List tags to hash seqs
+    pub hash_seq: bool,
+    /// List tags to raw blobs
+    pub raw: bool,
+    /// Optional from tag (inclusive)
+    pub from: Option<Tag>,
+    /// Optional to tag (exclusive)
+    pub to: Option<Tag>,
+}
+
+fn tags_from_range<R, E>(range: R) -> (Option<Tag>, Option<Tag>)
+where
+    R: RangeBounds<E>,
+    E: AsRef<[u8]>,
+{
+    let from = match range.start_bound() {
+        Bound::Included(start) => Some(Tag::from(start.as_ref())),
+        Bound::Excluded(start) => Some(Tag::from(start.as_ref()).successor()),
+        Bound::Unbounded => None,
+    };
+    let to = match range.end_bound() {
+        Bound::Included(end) => Some(Tag::from(end.as_ref()).successor()),
+        Bound::Excluded(end) => Some(Tag::from(end.as_ref())),
+        Bound::Unbounded => None,
+    };
+    (from, to)
+}
+
+impl ListOptions {
+    /// List a range of tags
+    pub fn range<R, E>(range: R) -> Self
+    where
+        R: RangeBounds<E>,
+        E: AsRef<[u8]>,
+    {
+        let (from, to) = tags_from_range(range);
+        Self {
+            from,
+            to,
+            raw: true,
+            hash_seq: true,
+        }
+    }
+
+    /// List tags with a prefix
+    pub fn prefix(prefix: &[u8]) -> Self {
+        let from = Tag::from(prefix);
+        let to = from.next_prefix();
+        Self {
+            raw: true,
+            hash_seq: true,
+            from: Some(from),
+            to,
+        }
+    }
+
+    /// List a single tag
+    pub fn single(name: &[u8]) -> Self {
+        let from = Tag::from(name);
+        Self {
+            to: Some(from.successor()),
+            from: Some(from),
+            raw: true,
+            hash_seq: true,
+        }
+    }
+
+    /// List all tags
+    pub fn all() -> Self {
+        Self {
+            raw: true,
+            hash_seq: true,
+            from: None,
+            to: None,
+        }
+    }
+
+    /// List raw tags
+    pub fn raw() -> Self {
+        Self {
+            raw: true,
+            hash_seq: false,
+            from: None,
+            to: None,
+        }
+    }
+
+    /// List hash seq tags
+    pub fn hash_seq() -> Self {
+        Self {
+            raw: false,
+            hash_seq: true,
+            from: None,
+            to: None,
+        }
+    }
+}
+
+/// Options for a delete operation.
+#[derive(Debug, Clone)]
+pub struct DeleteOptions {
+    /// Optional from tag (inclusive)
+    pub from: Option<Tag>,
+    /// Optional to tag (exclusive)
+    pub to: Option<Tag>,
+}
+
+impl DeleteOptions {
+    pub fn single(name: Tag) -> Self {
+        Self {
+            to: Some(name.successor()),
+            from: Some(name),
+        }
+    }
+}
+
 /// A client that uses the memory connector.
 pub type MemClient = Client<crate::rpc::MemConnector>;
 
@@ -42,13 +163,36 @@ where
         Self { rpc }
     }
 
+    /// List all tags with options.
+    ///
+    /// This is the most flexible way to list tags. All the other list methods are just convenience
+    /// methods that call this one with the appropriate options.
+    pub async fn list_with_opts(
+        &self,
+        options: ListOptions,
+    ) -> Result<impl Stream<Item = Result<TagInfo>>> {
+        let stream = self
+            .rpc
+            .server_streaming(ListRequest::from(options))
+            .await?;
+        Ok(stream.map(|res| res.map_err(anyhow::Error::from)))
+    }
+
     /// Get the value of a single tag
     pub async fn get(&self, name: impl AsRef<[u8]>) -> Result<Option<TagInfo>> {
         let mut stream = self
-            .rpc
-            .server_streaming(ListRequest::single(name.as_ref()))
+            .list_with_opts(ListOptions::single(name.as_ref()))
             .await?;
         Ok(stream.next().await.transpose()?)
+    }
+
+    /// List a range of tags
+    pub async fn list_range<R, E>(&self, range: R) -> Result<impl Stream<Item = Result<TagInfo>>>
+    where
+        R: RangeBounds<E>,
+        E: AsRef<[u8]>,
+    {
+        self.list_with_opts(ListOptions::range(range)).await
     }
 
     /// Lists all tags.
@@ -56,29 +200,29 @@ where
         &self,
         prefix: impl AsRef<[u8]>,
     ) -> Result<impl Stream<Item = Result<TagInfo>>> {
-        let stream = self
-            .rpc
-            .server_streaming(ListRequest::prefix(prefix.as_ref()))
-            .await?;
-        Ok(stream.map(|res| res.map_err(anyhow::Error::from)))
+        self.list_with_opts(ListOptions::prefix(prefix.as_ref()))
+            .await
     }
 
     /// Lists all tags.
     pub async fn list(&self) -> Result<impl Stream<Item = Result<TagInfo>>> {
-        let stream = self.rpc.server_streaming(ListRequest::all()).await?;
-        Ok(stream.map(|res| res.map_err(anyhow::Error::from)))
+        self.list_with_opts(ListOptions::all()).await
     }
 
     /// Lists all tags with a hash_seq format.
     pub async fn list_hash_seq(&self) -> Result<impl Stream<Item = Result<TagInfo>>> {
-        let stream = self.rpc.server_streaming(ListRequest::hash_seq()).await?;
-        Ok(stream.map(|res| res.map_err(anyhow::Error::from)))
+        self.list_with_opts(ListOptions::hash_seq()).await
+    }
+
+    /// Deletes a tag.
+    pub async fn delete_with_opts(&self, options: DeleteOptions) -> Result<()> {
+        self.rpc.rpc(DeleteRequest::from(options)).await??;
+        Ok(())
     }
 
     /// Deletes a tag.
     pub async fn delete(&self, name: Tag) -> Result<()> {
-        self.rpc.rpc(DeleteRequest { name }).await??;
-        Ok(())
+        self.delete_with_opts(DeleteOptions::single(name)).await
     }
 }
 

--- a/src/rpc/proto/tags.rs
+++ b/src/rpc/proto/tags.rs
@@ -20,6 +20,8 @@ pub enum Request {
     #[rpc(response = RpcResult<()>)]
     Set(SetRequest),
     #[rpc(response = RpcResult<()>)]
+    Rename(RenameRequest),
+    #[rpc(response = RpcResult<()>)]
     DeleteTag(DeleteRequest),
     #[server_streaming(response = TagInfo)]
     ListTags(ListRequest),
@@ -110,4 +112,13 @@ impl From<DeleteOptions> for DeleteRequest {
             to: options.to,
         }
     }
+}
+
+/// Rename a tag atomically
+#[derive(Debug, Serialize, Deserialize)]
+pub struct RenameRequest {
+    /// Old tag name
+    pub from: Tag,
+    /// New tag name
+    pub to: Tag,
 }

--- a/src/rpc/proto/tags.rs
+++ b/src/rpc/proto/tags.rs
@@ -6,7 +6,10 @@ use serde::{Deserialize, Serialize};
 
 use super::{RpcResult, RpcService};
 use crate::{
-    net_protocol::BatchId, rpc::client::tags::TagInfo, util::increment_vec, HashAndFormat, Tag,
+    net_protocol::BatchId,
+    rpc::client::tags::TagInfo,
+    util::{increment_vec, next_prefix},
+    HashAndFormat, Tag,
 };
 
 #[allow(missing_docs)]
@@ -83,6 +86,22 @@ pub struct ListRequest {
 }
 
 impl ListRequest {
+    /// List tags with a prefix
+    pub fn prefix(prefix: Tag) -> Self {
+        let mut to = prefix.0.to_vec();
+        let to = if next_prefix(&mut to) {
+            Some(Bytes::from(to).into())
+        } else {
+            None
+        };
+        Self {
+            raw: true,
+            hash_seq: true,
+            from: Some(prefix),
+            to,
+        }
+    }
+
     /// List a single tag
     pub fn single(name: Tag) -> Self {
         let mut next = name.0.to_vec();

--- a/src/rpc/proto/tags.rs
+++ b/src/rpc/proto/tags.rs
@@ -87,8 +87,10 @@ pub struct ListRequest {
 
 impl ListRequest {
     /// List tags with a prefix
-    pub fn prefix(prefix: Tag) -> Self {
-        let mut to = prefix.0.to_vec();
+    pub fn prefix(prefix: &[u8]) -> Self {
+        let from = prefix.to_vec();
+        let mut to = from.clone();
+        let from = Bytes::from(from).into();
         let to = if next_prefix(&mut to) {
             Some(Bytes::from(to).into())
         } else {
@@ -97,21 +99,23 @@ impl ListRequest {
         Self {
             raw: true,
             hash_seq: true,
-            from: Some(prefix),
+            from: Some(from),
             to,
         }
     }
 
     /// List a single tag
-    pub fn single(name: Tag) -> Self {
-        let mut next = name.0.to_vec();
+    pub fn single(name: &[u8]) -> Self {
+        let from = name.to_vec();
+        let mut next = from.clone();
         increment_vec(&mut next);
-        let next = Bytes::from(next).into();
+        let from = Bytes::from(from).into();
+        let to = Bytes::from(next).into();
         Self {
             raw: true,
             hash_seq: true,
-            from: Some(name),
-            to: Some(next),
+            from: Some(from),
+            to: Some(to),
         }
     }
 

--- a/src/rpc/proto/tags.rs
+++ b/src/rpc/proto/tags.rs
@@ -60,8 +60,8 @@ pub struct CreateRequest {
 pub struct SetRequest {
     /// Name of the tag
     pub name: Tag,
-    /// Value of the tag, None to delete
-    pub value: Option<HashAndFormat>,
+    /// Value of the tag
+    pub value: HashAndFormat,
     /// Batch to use, none for global
     pub batch: Option<BatchId>,
     /// Sync mode

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -86,7 +86,6 @@ use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
 use tokio::io::AsyncWriteExt;
 use tracing::trace_span;
-
 mod tables;
 #[doc(hidden)]
 pub mod test_support;

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -208,6 +208,18 @@ impl super::Store for Store {
         .await?
     }
 
+    async fn rename_tag(&self, from: Tag, to: Tag) -> io::Result<()> {
+        let mut state = self.write_lock();
+        let value = state.tags.remove(&from).ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("tag not found: {:?}", from),
+            )
+        })?;
+        state.tags.insert(to, value);
+        Ok(())
+    }
+
     async fn set_tag(&self, name: Tag, value: HashAndFormat) -> io::Result<()> {
         let mut state = self.write_lock();
         state.tags.insert(name, value);

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -17,6 +17,7 @@ use bao_tree::{
 use bytes::{Bytes, BytesMut};
 use futures_lite::{Stream, StreamExt};
 use iroh_io::AsyncSliceReader;
+use tracing::info;
 
 use super::{
     temp_name, BaoBatchWriter, ConsistencyCheckProgress, ExportMode, ExportProgressCb, ImportMode,
@@ -215,6 +216,8 @@ impl super::Store for Store {
 
     async fn delete_tags(&self, from: Option<Tag>, to: Option<Tag>) -> io::Result<()> {
         let mut state = self.write_lock();
+        info!("deleting tags from {:?} to {:?}", from, to);
+        // state.tags.remove(&from.unwrap());
         // todo: more efficient impl
         state.tags.retain(|tag, _| {
             if let Some(from) = &from {
@@ -227,6 +230,7 @@ impl super::Store for Store {
                     return true;
                 }
             }
+            info!("    removing {:?}", tag);
             false
         });
         Ok(())

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -207,13 +207,28 @@ impl super::Store for Store {
         .await?
     }
 
-    async fn set_tag(&self, name: Tag, value: Option<HashAndFormat>) -> io::Result<()> {
+    async fn set_tag(&self, name: Tag, value: HashAndFormat) -> io::Result<()> {
         let mut state = self.write_lock();
-        if let Some(value) = value {
-            state.tags.insert(name, value);
-        } else {
-            state.tags.remove(&name);
-        }
+        state.tags.insert(name, value);
+        Ok(())
+    }
+
+    async fn delete_tags(&self, from: Option<Tag>, to: Option<Tag>) -> io::Result<()> {
+        let mut state = self.write_lock();
+        // todo: more efficient impl
+        state.tags.retain(|tag, _| {
+            if let Some(from) = &from {
+                if tag < from {
+                    return true;
+                }
+            }
+            if let Some(to) = &to {
+                if tag >= to {
+                    return true;
+                }
+            }
+            false
+        });
         Ok(())
     }
 

--- a/src/store/readonly_mem.rs
+++ b/src/store/readonly_mem.rs
@@ -307,6 +307,10 @@ impl super::Store for Store {
         Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
     }
 
+    async fn rename_tag(&self, _from: Tag, _to: Tag) -> io::Result<()> {
+        Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
+    }
+
     async fn import_stream(
         &self,
         data: impl Stream<Item = io::Result<Bytes>> + Unpin + Send,

--- a/src/store/readonly_mem.rs
+++ b/src/store/readonly_mem.rs
@@ -313,7 +313,11 @@ impl super::Store for Store {
         Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
     }
 
-    async fn set_tag(&self, _name: Tag, _hash: Option<HashAndFormat>) -> io::Result<()> {
+    async fn set_tag(&self, _name: Tag, _hash: HashAndFormat) -> io::Result<()> {
+        Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
+    }
+
+    async fn delete_tags(&self, _from: Option<Tag>, _to: Option<Tag>) -> io::Result<()> {
         Err(io::Error::new(io::ErrorKind::Other, "not implemented"))
     }
 

--- a/src/store/readonly_mem.rs
+++ b/src/store/readonly_mem.rs
@@ -232,7 +232,11 @@ impl ReadableStore for Store {
         ))
     }
 
-    async fn tags(&self) -> io::Result<DbIter<(Tag, HashAndFormat)>> {
+    async fn tags(
+        &self,
+        _from: Option<Tag>,
+        _to: Option<Tag>,
+    ) -> io::Result<DbIter<(Tag, HashAndFormat)>> {
         Ok(Box::new(std::iter::empty()))
     }
 

--- a/src/store/traits.rs
+++ b/src/store/traits.rs
@@ -345,7 +345,19 @@ pub trait Store: ReadableStore + MapMut + std::fmt::Debug {
     fn set_tag(
         &self,
         name: Tag,
-        hash: Option<HashAndFormat>,
+        hash: HashAndFormat,
+    ) -> impl Future<Output = io::Result<()>> + Send;
+
+    /// Delete a single tag
+    fn delete_tag(&self, name: Tag) -> impl Future<Output = io::Result<()>> + Send {
+        self.delete_tags(Some(name.clone()), Some(name.successor()))
+    }
+
+    /// Bulk delete tags
+    fn delete_tags(
+        &self,
+        from: Option<Tag>,
+        to: Option<Tag>,
     ) -> impl Future<Output = io::Result<()>> + Send;
 
     /// Create a new tag

--- a/src/store/traits.rs
+++ b/src/store/traits.rs
@@ -352,6 +352,9 @@ pub trait Store: ReadableStore + MapMut + std::fmt::Debug {
         hash: HashAndFormat,
     ) -> impl Future<Output = io::Result<()>> + Send;
 
+    /// Rename a tag
+    fn rename_tag(&self, from: Tag, to: Tag) -> impl Future<Output = io::Result<()>> + Send;
+
     /// Delete a single tag
     fn delete_tag(&self, name: Tag) -> impl Future<Output = io::Result<()>> + Send {
         self.delete_tags(Some(name.clone()), Some(name.successor()))

--- a/src/store/traits.rs
+++ b/src/store/traits.rs
@@ -262,7 +262,11 @@ pub trait ReadableStore: Map {
     /// been imported, and hash sequences that have been created internally.
     fn blobs(&self) -> impl Future<Output = io::Result<DbIter<Hash>>> + Send;
     /// list all tags (collections or other explicitly added things) in the database
-    fn tags(&self) -> impl Future<Output = io::Result<DbIter<(Tag, HashAndFormat)>>> + Send;
+    fn tags(
+        &self,
+        from: Option<Tag>,
+        to: Option<Tag>,
+    ) -> impl Future<Output = io::Result<DbIter<(Tag, HashAndFormat)>>> + Send;
 
     /// Temp tags
     fn temp_tags(&self) -> Box<dyn Iterator<Item = HashAndFormat> + Send + Sync + 'static>;
@@ -635,7 +639,7 @@ pub(super) async fn gc_mark_task<'a>(
     }
     let mut roots = BTreeSet::new();
     debug!("traversing tags");
-    for item in store.tags().await? {
+    for item in store.tags(None, None).await? {
         let (name, haf) = item?;
         debug!("adding root {:?} {:?}", name, haf);
         roots.insert(haf);

--- a/src/util.rs
+++ b/src/util.rs
@@ -302,6 +302,21 @@ pub(crate) fn raw_outboard_size(size: u64) -> u64 {
     BaoTree::new(size, IROH_BLOCK_SIZE).outboard_size()
 }
 
+/// Given a prefix, increment it lexographically.
+///
+/// If the prefix is all FF, this will return false because there is no
+/// higher prefix than that.
+pub(crate) fn next_prefix(bytes: &mut [u8]) -> bool {
+    for byte in bytes.iter_mut().rev() {
+        if *byte < 255 {
+            *byte += 1;
+            return true;
+        }
+        *byte = 0;
+    }
+    false
+}
+
 /// Increment a byte vector, lexographically.
 pub(crate) fn increment_vec(bytes: &mut Vec<u8>) {
     for byte in bytes.iter_mut().rev() {

--- a/src/util.rs
+++ b/src/util.rs
@@ -306,6 +306,7 @@ pub(crate) fn raw_outboard_size(size: u64) -> u64 {
 ///
 /// If the prefix is all FF, this will return false because there is no
 /// higher prefix than that.
+#[allow(dead_code)]
 pub(crate) fn next_prefix(bytes: &mut [u8]) -> bool {
     for byte in bytes.iter_mut().rev() {
         if *byte < 255 {
@@ -318,6 +319,7 @@ pub(crate) fn next_prefix(bytes: &mut [u8]) -> bool {
 }
 
 /// Increment a byte vector, lexographically.
+#[allow(dead_code)]
 pub(crate) fn increment_vec(bytes: &mut Vec<u8>) {
     for byte in bytes.iter_mut().rev() {
         if *byte < 255 {

--- a/src/util.rs
+++ b/src/util.rs
@@ -148,7 +148,8 @@ impl Tag {
     /// The successor of this tag in lexicographic order.
     pub fn successor(&self) -> Self {
         let mut bytes = self.0.to_vec();
-        increment_vec(&mut bytes);
+        // increment_vec(&mut bytes);
+        bytes.push(0);
         Self(bytes.into())
     }
 
@@ -347,20 +348,6 @@ pub(crate) fn next_prefix(bytes: &mut [u8]) -> bool {
         *byte = 0;
     }
     false
-}
-
-/// Increment a byte vector, lexographically.
-#[allow(dead_code)]
-pub(crate) fn increment_vec(bytes: &mut Vec<u8>) {
-    for byte in bytes.iter_mut().rev() {
-        if *byte < 255 {
-            *byte += 1;
-            return;
-        }
-        *byte = 0;
-    }
-
-    bytes.push(0);
 }
 
 /// Synchronously compute the outboard of a file, and return hash and outboard.

--- a/src/util.rs
+++ b/src/util.rs
@@ -74,6 +74,18 @@ mod redb_support {
     }
 }
 
+impl From<&[u8]> for Tag {
+    fn from(value: &[u8]) -> Self {
+        Self(Bytes::copy_from_slice(value))
+    }
+}
+
+impl AsRef<[u8]> for Tag {
+    fn as_ref(&self) -> &[u8] {
+        self.0.as_ref()
+    }
+}
+
 impl Borrow<[u8]> for Tag {
     fn borrow(&self) -> &[u8] {
         self.0.as_ref()
@@ -130,6 +142,25 @@ impl Tag {
                 return Self::from(text);
             }
             i += 1;
+        }
+    }
+
+    /// The successor of this tag in lexicographic order.
+    pub fn successor(&self) -> Self {
+        let mut bytes = self.0.to_vec();
+        increment_vec(&mut bytes);
+        Self(bytes.into())
+    }
+
+    /// If this is a prefix, get the next prefix.
+    ///
+    /// This is like successor, except that it will return None if the prefix is all 0xFF instead of appending a 0 byte.
+    pub fn next_prefix(&self) -> Option<Self> {
+        let mut bytes = self.0.to_vec();
+        if next_prefix(&mut bytes) {
+            Some(Self(bytes.into()))
+        } else {
+            None
         }
     }
 }

--- a/src/util.rs
+++ b/src/util.rs
@@ -302,6 +302,19 @@ pub(crate) fn raw_outboard_size(size: u64) -> u64 {
     BaoTree::new(size, IROH_BLOCK_SIZE).outboard_size()
 }
 
+/// Increment a byte vector, lexographically.
+pub(crate) fn increment_vec(bytes: &mut Vec<u8>) {
+    for byte in bytes.iter_mut().rev() {
+        if *byte < 255 {
+            *byte += 1;
+            return;
+        }
+        *byte = 0;
+    }
+
+    bytes.push(0);
+}
+
 /// Synchronously compute the outboard of a file, and return hash and outboard.
 ///
 /// It is assumed that the file is not modified while this is running.

--- a/tests/tags.rs
+++ b/tests/tags.rs
@@ -1,0 +1,115 @@
+#![cfg(all(feature = "net_protocol", feature = "rpc"))]
+use futures_lite::StreamExt;
+use futures_util::Stream;
+use iroh::Endpoint;
+use iroh_blobs::{
+    net_protocol::Blobs,
+    rpc::{
+        client::tags::{self, TagInfo},
+        proto::RpcService,
+    },
+    BlobFormat, Hash,
+};
+use testresult::TestResult;
+
+async fn to_vec<T>(stream: impl Stream<Item = anyhow::Result<T>>) -> anyhow::Result<Vec<T>> {
+    let res = stream.collect::<Vec<_>>().await;
+    res.into_iter().collect::<anyhow::Result<Vec<_>>>()
+}
+
+fn expected(tags: impl IntoIterator<Item = &'static str>) -> Vec<TagInfo> {
+    tags.into_iter()
+        .map(|tag| TagInfo {
+            name: tag.into(),
+            hash: Hash::new(tag),
+            format: BlobFormat::Raw,
+        })
+        .collect()
+}
+
+async fn tags_smoke<C: quic_rpc::Connector<RpcService>>(tags: tags::Client<C>) -> TestResult<()> {
+    tags.set("a", Hash::new("a")).await?;
+    tags.set("b", Hash::new("b")).await?;
+    tags.set("c", Hash::new("c")).await?;
+    tags.set("d", Hash::new("d")).await?;
+    tags.set("e", Hash::new("e")).await?;
+    let stream = tags.list().await?;
+    let res = to_vec(stream).await?;
+    assert_eq!(res, expected(["a", "b", "c", "d", "e"]));
+
+    let stream = tags.list_range("b".."d").await?;
+    let res = to_vec(stream).await?;
+    assert_eq!(res, expected(["b", "c"]));
+
+    let stream = tags.list_range("b"..).await?;
+    let res = to_vec(stream).await?;
+    assert_eq!(res, expected(["b", "c", "d", "e"]));
+
+    let stream = tags.list_range(.."d").await?;
+    let res = to_vec(stream).await?;
+    assert_eq!(res, expected(["a", "b", "c"]));
+
+    let stream = tags.list_range(..="d").await?;
+    let res = to_vec(stream).await?;
+    assert_eq!(res, expected(["a", "b", "c", "d"]));
+
+    tags.delete_range("b"..).await?;
+    let stream = tags.list().await?;
+    let res = to_vec(stream).await?;
+    assert_eq!(res, expected(["a"]));
+
+    tags.delete_range(..="a").await?;
+    let stream = tags.list().await?;
+    let res = to_vec(stream).await?;
+    assert_eq!(res, expected([]));
+
+    tags.set("a", Hash::new("a")).await?;
+    tags.set("aa", Hash::new("aa")).await?;
+    tags.set("aaa", Hash::new("aaa")).await?;
+    tags.set("aab", Hash::new("aab")).await?;
+    tags.set("b", Hash::new("b")).await?;
+
+    let stream = tags.list_prefix("aa").await?;
+    let res = to_vec(stream).await?;
+    assert_eq!(res, expected(["aa", "aaa", "aab"]));
+
+    tags.delete_prefix("aa").await?;
+    let stream = tags.list().await?;
+    let res = to_vec(stream).await?;
+    assert_eq!(res, expected(["a", "b"]));
+
+    tags.delete_prefix("").await?;
+    let stream = tags.list().await?;
+    let res = to_vec(stream).await?;
+    assert_eq!(res, expected([]));
+
+    tags.set("a", Hash::new("a")).await?;
+    tags.set("b", Hash::new("b")).await?;
+    tags.set("c", Hash::new("c")).await?;
+
+    tags.delete("b").await?;
+    let stream = tags.list().await?;
+    let res = to_vec(stream).await?;
+    assert_eq!(res, expected(["a", "c"]));
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn tags_smoke_mem() -> TestResult<()> {
+    let endpoint = Endpoint::builder().bind().await?;
+    let blobs = Blobs::memory().build(&endpoint);
+    let client = blobs.client();
+    tags_smoke(client.tags()).await
+}
+
+#[tokio::test]
+async fn tags_smoke_fs() -> TestResult<()> {
+    let td = tempfile::tempdir()?;
+    let endpoint = Endpoint::builder().bind().await?;
+    let blobs = Blobs::persistent(td.path().join("blobs.db"))
+        .await?
+        .build(&endpoint);
+    let client = blobs.client();
+    tags_smoke(client.tags()).await
+}

--- a/tests/tags.rs
+++ b/tests/tags.rs
@@ -87,10 +87,21 @@ async fn tags_smoke<C: quic_rpc::Connector<RpcService>>(tags: tags::Client<C>) -
     tags.set("b", Hash::new("b")).await?;
     tags.set("c", Hash::new("c")).await?;
 
+    assert_eq!(
+        tags.get("b").await?,
+        Some(TagInfo {
+            name: "b".into(),
+            hash: Hash::new("b"),
+            format: BlobFormat::Raw,
+        })
+    );
+
     tags.delete("b").await?;
     let stream = tags.list().await?;
     let res = to_vec(stream).await?;
     assert_eq!(res, expected(["a", "c"]));
+
+    assert_eq!(tags.get("b").await?, None);
 
     Ok(())
 }


### PR DESCRIPTION
## Description

This makes the anemic tags api much more rich

- Tag deletion
  - delete by range, by prefix, single item, or all 💣 
- Tag listing
  - list by range, prefix or get single item
- Tag setting
  - set a tag to a value
- Tag renaming
  - atomic rename, just like for files

## Breaking Changes

Breaks the RPC protocol and the store trait

RPC protocol:

- rpc::proto::tags::DeleteRequest now has from and to field
- rpc::proto::tags::DeleteRequest no longer has name field
- rpc::proto::tags::ListRequest now has from and to field
- rpc::proto::tags::ListRequest::all removed
- rpc::proto::tags::ListRequest::raw removed
- rpc::proto::tags::ListRequest::hash_seq removed

Store trait:

- store::traits::ReadableStore::tags now takes from and to

## Notes & open questions

Question: should we enable the rpc feature flag by default? Given that the only way to get the pleasant API at this time is the rpc, and we want beginners to have a good experience? In my big refactor you will be able to get this API without rpc enabled, but for now this is just how it is.

Implements https://github.com/n0-computer/iroh-blobs/issues/65

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
