### PR TITLE
feat: ability to open a hash as a seekable bao file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -349,8 +349,7 @@ dependencies = [
 [[package]]
 name = "bao-tree"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f7a89a8ee5889d2593ae422ce6e1bb03e48a0e8a16e4fa0882dfcbe7e182ef"
+source = "git+https://github.com/n0-computer/bao-tree?branch=read_and_seek#bff3195faa89636b8bdb2ff69bf7e9d532565df6"
 dependencies = [
  "bytes",
  "futures-lite",
@@ -361,6 +360,7 @@ dependencies = [
  "range-collections",
  "self_cell",
  "smallvec",
+ "tokio",
 ]
 
 [[package]]
@@ -2103,6 +2103,7 @@ dependencies = [
  "oneshot",
  "parking_lot",
  "portable-atomic",
+ "positioned-io",
  "postcard",
  "proptest",
  "quic-rpc",
@@ -3277,6 +3278,7 @@ version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccabfeeb89c73adf4081f0dca7f8e28dbda90981a222ceea37f619e93ea6afe9"
 dependencies = [
+ "byteorder",
  "libc",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ async-channel = "2.3.1"
 bao-tree = { version = "0.13", features = [
     "tokio_fsm",
     "validate",
+    "experimental-mixed",
 ], default-features = false }
 blake3 = { version = "1.4.5", package = "iroh-blake3" }
 bytes = { version = "1.7", features = ["serde"] }
@@ -77,6 +78,7 @@ walkdir = { version = "2.5.0", optional = true }
 # Examples
 console = { version = "0.15.8", optional = true }
 tracing-test = "0.2.5"
+positioned-io = "0.3.3"
 
 [dev-dependencies]
 http-body = "1.0"
@@ -189,3 +191,4 @@ incremental = false
 iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
 iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
 quic-rpc = { git = "https://github.com/n0-computer/quic-rpc", branch = "main" }
+bao-tree = { git = "https://github.com/n0-computer/bao-tree", branch = "read_and_seek" }

--- a/src/rpc/proto/blobs.rs
+++ b/src/rpc/proto/blobs.rs
@@ -15,8 +15,8 @@ use crate::{
     provider::{AddProgress, BatchAddPathProgress},
     rpc::client::blobs::{BlobInfo, BlobStatus, IncompleteBlobInfo, ReadAtLen, WrapOption},
     store::{
-        BaoBlobSize, ConsistencyCheckProgress, ExportFormat, ExportMode, ImportMode,
-        ValidateProgress,
+        BaoBlobSize, ConsistencyCheckProgress, EntryPathOrData, ExportFormat, ExportMode,
+        ImportMode, ValidateProgress,
     },
     util::SetTagOption,
     BlobFormat, Hash, HashAndFormat, Tag,
@@ -63,6 +63,8 @@ pub enum Request {
     BatchAddPath(BatchAddPathRequest),
     #[rpc(response = RpcResult<()>)]
     BatchCreateTempTag(BatchCreateTempTagRequest),
+    #[rpc(response = RpcResult<Option<EntryPathOrData>>)]
+    EntryInfo(BlobEntryInfoRequest),
 }
 
 #[allow(missing_docs)]
@@ -83,6 +85,7 @@ pub enum Response {
     BatchCreate(BatchCreateResponse),
     BatchAddStream(BatchAddStreamResponse),
     BatchAddPath(BatchAddPathResponse),
+    EntryInfo(RpcResult<Option<EntryPathOrData>>),
 }
 
 /// A request to the node to provide the data at the given path
@@ -311,6 +314,13 @@ pub struct BatchAddPathRequest {
     pub format: BlobFormat,
     /// Batch to create the temp tag in
     pub batch: BatchId,
+}
+
+/// Write a blob from a byte stream
+#[derive(Serialize, Deserialize, Debug)]
+pub struct BlobEntryInfoRequest {
+    /// The hash of the blob
+    pub hash: Hash,
 }
 
 /// Response to a batch add path request

--- a/src/store/traits.rs
+++ b/src/store/traits.rs
@@ -43,7 +43,7 @@ pub enum EntryStatus {
 }
 
 /// Get the path or data for an entry
-#[derive(Debug)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct EntryPathOrData {
     /// The path to the data file or the inline data
     pub data: MemOrFile<Bytes, (PathBuf, u64)>,

--- a/src/store/traits.rs
+++ b/src/store/traits.rs
@@ -20,7 +20,7 @@ use crate::{
     util::{
         local_pool::{self, LocalPool},
         progress::{BoxedProgressSender, IdGenerator, ProgressSender},
-        Tag,
+        MemOrFile, Tag,
     },
     BlobFormat, Hash, HashAndFormat, TempTag, IROH_BLOCK_SIZE,
 };
@@ -40,6 +40,15 @@ pub enum EntryStatus {
     Partial,
     /// The entry is not in the store.
     NotFound,
+}
+
+/// Get the path or data for an entry
+#[derive(Debug)]
+pub struct EntryPathOrData {
+    /// The path to the data file or the inline data
+    pub data: MemOrFile<Bytes, (PathBuf, u64)>,
+    /// The path to the outboard file, or the inline outboard
+    pub outboard: MemOrFile<Bytes, PathBuf>,
 }
 
 /// The size of a bao file
@@ -384,6 +393,12 @@ pub trait Store: ReadableStore + MapMut + std::fmt::Debug {
     ) -> impl Future<Output = io::Result<()>> + Send {
         validate_impl(self, repair, tx)
     }
+
+    /// Get the info needed to open an entry independently of the store.
+    fn entry_path_or_data(
+        &self,
+        hash: Hash,
+    ) -> impl Future<Output = io::Result<Option<EntryPathOrData>>> + Send;
 }
 
 async fn validate_impl(


### PR DESCRIPTION
## Description

Adds the ability to open a *partial or complete* hash as a file that supports std::io::Read and std::io::Seek. If you read at a position where the data is not present, you will get an io error, since all reads are validated.

The created file will be completely independent of the store, you can use it even when the store is dropped.

This relies on some experimental code in bao-tree. I will also support it in the new store.

The underlying implementation is using positioned_io::ReadAt, and I also have a wrapper similar to tokio::io::Cursor that wraps the file so that it impls tokio:io::AsyncRead and tokio::io::AsyncSeek.

## Breaking Changes

None?

## Notes & open questions

This is very WIP

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
