### PR TITLE
feat: Enable RPC by default

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ futures-util = "0.3.30"
 testdir = "0.9.1"
 
 [features]
-default = ["fs-store", "net_protocol"]
+default = ["fs-store", "net_protocol", "rpc"]
 downloader = ["dep:parking_lot", "tokio-util/time", "dep:hashlink"]
 net_protocol = ["downloader", "dep:futures-util"]
 fs-store = ["dep:reflink-copy", "redb", "dep:tempfile"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,17 @@
 //! The [downloader] module provides a component to download blobs from
 //! multiple sources and store them in a store.
 //!
+//! # Feature flags
+//!
+//! - rpc: Enable the rpc server and client. Enabled by default.
+//! - net_protocol: Enable the network protocol. Enabled by default.
+//! - downloader: Enable the downloader. Enabled by default.
+//! - fs-store: Enable the filesystem store. Enabled by default.
+//!
+//! - cli: Enable the cli. Disabled by default.
+//! - example-iroh: dependencies for examples in this crate. Disabled by default.
+//! - test: test utilities. Disabled by default.
+//!
 //! [BLAKE3]: https://github.com/BLAKE3-team/BLAKE3-specs/blob/master/blake3.pdf
 //! [iroh]: https://docs.rs/iroh
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -2043,7 +2043,7 @@ impl ActorState {
     fn rename_tag(&mut self, tables: &mut Tables, from: Tag, to: Tag) -> ActorResult<()> {
         let value = tables
             .tags
-            .get(from)?
+            .remove(from)?
             .ok_or_else(|| {
                 ActorError::Io(io::Error::new(io::ErrorKind::NotFound, "tag not found"))
             })?


### PR DESCRIPTION
## Description

Almost the entire friendly API of the crate is only available if the `rpc` feature flag is set. So this enables rpc by default to make the crate easier to use for beginners.

I also document feature flags in the module docs (should this instead be in README.md?) so people that need fewer deps know what to do.

## Breaking Changes

None

## Notes & open questions

Note: there is also a bugfix to the new tags API. The rename fn in the API was not actually using the shiny new atomic rename but just the multi-step rename. If we decide not to enable rpc by default I will move that change into a separate PR.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
