### PR TITLE
feat!: Allow configuring the downloader when creating a blobs protocol handler

### DIFF
--- a/src/net_protocol.rs
+++ b/src/net_protocol.rs
@@ -172,14 +172,18 @@ impl<S: crate::store::Store> Builder<S> {
 
     /// Set custom [`ConcurrencyLimits`] to use.
     pub fn concurrency_limits(mut self, concurrency_limits: ConcurrencyLimits) -> Self {
-        let downloader_config = self.downloader_config.get_or_insert_default();
+        let downloader_config = self
+            .downloader_config
+            .get_or_insert_with(|| Default::default());
         downloader_config.concurrency = concurrency_limits;
         self
     }
 
     /// Set a custom [`RetryConfig`] to use.
     pub fn retry_config(mut self, retry_config: RetryConfig) -> Self {
-        let downloader_config = self.downloader_config.get_or_insert_default();
+        let downloader_config = self
+            .downloader_config
+            .get_or_insert_with(|| Default::default());
         downloader_config.retry = retry_config;
         self
     }

--- a/src/net_protocol.rs
+++ b/src/net_protocol.rs
@@ -142,18 +142,12 @@ impl BlobBatches {
     }
 }
 
-#[derive(Debug, Default)]
-pub struct DownloaderConfig {
-    pub concurrency: downloader::ConcurrencyLimits,
-    pub retry: downloader::RetryConfig,
-}
-
 /// Builder for the Blobs protocol handler
 #[derive(Debug)]
 pub struct Builder<S> {
     store: S,
     events: Option<EventSender>,
-    downloader: Option<DownloaderConfig>,
+    downloader: Option<crate::downloader::Config>,
     rt: Option<LocalPoolHandle>,
 }
 
@@ -171,7 +165,7 @@ impl<S: crate::store::Store> Builder<S> {
     }
 
     /// Set a custom downloader configuration.
-    pub fn downloader(mut self, config: DownloaderConfig) -> Self {
+    pub fn downloader(mut self, config: downloader::Config) -> Self {
         self.downloader = Some(config);
         self
     }
@@ -183,7 +177,7 @@ impl<S: crate::store::Store> Builder<S> {
             .rt
             .map(Rt::Handle)
             .unwrap_or_else(|| Rt::Owned(LocalPool::default()));
-        let DownloaderConfig { concurrency, retry } = self.downloader.unwrap_or_default();
+        let downloader::Config { concurrency, retry } = self.downloader.unwrap_or_default();
         let downloader = Downloader::with_config(
             self.store.clone(),
             endpoint.clone(),

--- a/src/net_protocol.rs
+++ b/src/net_protocol.rs
@@ -177,13 +177,12 @@ impl<S: crate::store::Store> Builder<S> {
             .rt
             .map(Rt::Handle)
             .unwrap_or_else(|| Rt::Owned(LocalPool::default()));
-        let downloader::Config { concurrency, retry } = self.downloader.unwrap_or_default();
+        let downloader_config = self.downloader.unwrap_or_default();
         let downloader = Downloader::with_config(
             self.store.clone(),
             endpoint.clone(),
             rt.clone(),
-            concurrency,
-            retry,
+            downloader_config,
         );
         Blobs::new(
             self.store,

--- a/src/net_protocol.rs
+++ b/src/net_protocol.rs
@@ -172,18 +172,14 @@ impl<S: crate::store::Store> Builder<S> {
 
     /// Set custom [`ConcurrencyLimits`] to use.
     pub fn concurrency_limits(mut self, concurrency_limits: ConcurrencyLimits) -> Self {
-        let downloader_config = self
-            .downloader_config
-            .get_or_insert_with(|| Default::default());
+        let downloader_config = self.downloader_config.get_or_insert_with(Default::default);
         downloader_config.concurrency = concurrency_limits;
         self
     }
 
     /// Set a custom [`RetryConfig`] to use.
     pub fn retry_config(mut self, retry_config: RetryConfig) -> Self {
-        let downloader_config = self
-            .downloader_config
-            .get_or_insert_with(|| Default::default());
+        let downloader_config = self.downloader_config.get_or_insert_with(Default::default);
         downloader_config.retry = retry_config;
         self
     }

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test")]
 use std::{net::SocketAddr, path::PathBuf, vec};
 
-use iroh_blobs::net_protocol::Blobs;
+use iroh_blobs::{downloader, net_protocol::Blobs};
 use quic_rpc::client::QuinnConnector;
 use tempfile::TempDir;
 use testresult::TestResult;
@@ -83,5 +83,28 @@ async fn quinn_rpc_large() -> TestResult<()> {
     assert_eq!(hash, iroh_blobs::Hash::new(&data));
     let data2 = client.read_to_bytes(hash).await?;
     assert_eq!(data, &data2[..]);
+    Ok(())
+}
+
+#[tokio::test]
+async fn downloader_config() -> TestResult<()> {
+    let _ = tracing_subscriber::fmt::try_init();
+    let endpoint = iroh::Endpoint::builder().bind().await?;
+    let store = iroh_blobs::store::mem::Store::default();
+    let expected = downloader::Config {
+        concurrency: downloader::ConcurrencyLimits {
+            max_concurrent_requests: usize::MAX,
+            max_concurrent_requests_per_node: usize::MAX,
+            max_open_connections: usize::MAX,
+            max_concurrent_dials_per_hash: usize::MAX,
+        },
+        retry: downloader::RetryConfig {
+            max_retries_per_node: u32::MAX,
+            initial_retry_delay: std::time::Duration::from_secs(1),
+        },
+    };
+    let blobs = Blobs::builder(store).downloader(expected).build(&endpoint);
+    let actual = blobs.downloader().get_config().await?;
+    assert_eq!(expected, actual);
     Ok(())
 }

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -104,7 +104,7 @@ async fn downloader_config() -> TestResult<()> {
         },
     };
     let blobs = Blobs::builder(store).downloader(expected).build(&endpoint);
-    let actual = blobs.downloader().get_config().await?;
-    assert_eq!(expected, actual);
+    let actual = blobs.downloader().config();
+    assert_eq!(&expected, actual);
     Ok(())
 }


### PR DESCRIPTION
## Description

Allow configuring the downloader when creating a blobs protocol handler

we don't allow passing in the entire downloader, but all config options.

## Breaking Changes

`iroh_blobs::downloader::Downloader` now takes a `config: Config ` argument instead of `concurrency_limits: ConcurrencyLimits, retry_config: RetryConfig`. `Config` has two public field `concurrency_limits` and `retry_config`, so the migration is straightforward.

Otherwise there's only additions (a new method `downloader_config` on the `Blobs` constructor).

## Notes & open questions



## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
