### PR TITLE
chore: update bao-tree dependency and get rid of iroh-blake3 dep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,14 +346,14 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.13.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1f7a89a8ee5889d2593ae422ce6e1bb03e48a0e8a16e4fa0882dfcbe7e182ef"
+checksum = "ed75ed308ae4f69cf727de0068b967c97f2d62b5430408849ecda8ca06620bd9"
 dependencies = [
+ "blake3",
  "bytes",
  "futures-lite",
  "genawaiter",
- "iroh-blake3",
  "iroh-io",
  "positioned-io",
  "range-collections",
@@ -411,6 +411,19 @@ name = "bitflags"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c8214115b7bf84099f1309324e63141d4c5d7cc26862f97a0a857dbefe165bd"
+
+[[package]]
+name = "blake3"
+version = "1.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34a796731680be7931955498a16a10b2270c7762963d5d570fdbfe02dcbf314f"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+]
 
 [[package]]
 name = "block-buffer"
@@ -2072,25 +2085,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "iroh-blake3"
-version = "1.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbba31f40a650f58fa28dd585a8ca76d8ae3ba63aacab4c8269004a0c803930"
-dependencies = [
- "arrayref",
- "arrayvec",
- "cc",
- "cfg-if",
- "constant_time_eq",
-]
-
-[[package]]
 name = "iroh-blobs"
 version = "0.34.0"
 dependencies = [
  "anyhow",
  "async-channel",
  "bao-tree",
+ "blake3",
  "bytes",
  "chrono",
  "clap",
@@ -2107,7 +2108,6 @@ dependencies = [
  "indicatif",
  "iroh",
  "iroh-base",
- "iroh-blake3",
  "iroh-io",
  "iroh-metrics",
  "iroh-quinn",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,11 +15,11 @@ rust-version = "1.81"
 [dependencies]
 anyhow = { version = "1" }
 async-channel = "2.3.1"
-bao-tree = { version = "0.13", features = [
+bao-tree = { version = "0.15", features = [
     "tokio_fsm",
     "validate",
 ], default-features = false }
-blake3 = { version = "1.4.5", package = "iroh-blake3" }
+blake3 = { version = "1.8" }
 bytes = { version = "1.7", features = ["serde"] }
 chrono = "0.4.31"
 clap = { version = "4.5.20", features = ["derive"], optional = true }


### PR DESCRIPTION
## Description

Update bao-tree dependency and get rid of iroh-blake3 dep

## Breaking Changes

None

## Notes & open questions

Note: the purpose of this is to be able to retire our blake3 fork. It should not change anything other than that.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
