### PR TITLE
fix: use latest bao-tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -346,9 +346,9 @@ dependencies = [
 
 [[package]]
 name = "bao-tree"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed75ed308ae4f69cf727de0068b967c97f2d62b5430408849ecda8ca06620bd9"
+checksum = "ff16d65e48353db458be63ee395c03028f24564fd48668389bd65fd945f5ac36"
 dependencies = [
  "blake3",
  "bytes",
@@ -2149,9 +2149,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-io"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17e302c5ad649c6a7aa9ae8468e1c4dc2469321af0c6de7341c1be1bdaab434b"
+checksum = "e0a5feb781017b983ff1b155cd1faf8174da2acafd807aa482876da2d7e6577a"
 dependencies = [
  "bytes",
  "futures-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.81"
 [dependencies]
 anyhow = { version = "1" }
 async-channel = "2.3.1"
-bao-tree = { version = "0.15", features = [
+bao-tree = { version = "0.15.1", features = [
     "tokio_fsm",
     "validate",
 ], default-features = false }


### PR DESCRIPTION
## Description

Use latest bao-tree that fixes a bug when getting a short read

## Breaking Changes

None

## Notes & open questions

None

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
