### PR TITLE
Seanaye/persistence trait

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2086,7 +2086,7 @@ dependencies = [
 
 [[package]]
 name = "iroh-blobs"
-version = "0.34.1"
+version = "0.35.1"
 dependencies = [
  "anyhow",
  "async-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "iroh-blobs"
-version = "0.34.1"
+version = "0.35.1"
 edition = "2021"
 readme = "README.md"
 description = "blob and collection transfer support for iroh"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@
 #![deny(missing_docs, rustdoc::broken_intra_doc_links)]
 #![recursion_limit = "256"]
 #![cfg_attr(iroh_docsrs, feature(doc_auto_cfg))]
+#![feature(async_closure)]
 
 #[cfg(feature = "cli")]
 pub mod cli;

--- a/src/rpc/client/blobs.rs
+++ b/src/rpc/client/blobs.rs
@@ -1028,6 +1028,7 @@ mod tests {
             net_protocol::Blobs,
             provider::{CustomEventSender, EventSender},
             rpc::client::{blobs, tags},
+            store::fs::FileSystemPersistence,
         };
 
         type RpcClient = quic_rpc::RpcClient<RpcService>;
@@ -1113,7 +1114,8 @@ mod tests {
             /// Creates a new node with persistent storage
             pub async fn persistent(
                 path: impl AsRef<Path>,
-            ) -> anyhow::Result<Builder<crate::store::fs::Store>> {
+            ) -> anyhow::Result<Builder<crate::store::fs::Store<FileSystemPersistence>>>
+            {
                 Ok(Builder {
                     store: crate::store::fs::Store::load(path).await?,
                     events: Default::default(),

--- a/src/store/bao_file.rs
+++ b/src/store/bao_file.rs
@@ -82,13 +82,12 @@ struct DataPaths {
 /// For the memory variant, it does reading in a zero copy way, since storage
 /// is already a `Bytes`.
 #[derive(derive_more::Debug)]
-#[debug(bound(T: Debug))]
 pub struct CompleteStorage<T> {
     /// data part, which can be in memory or on disk.
-    #[debug("{:?}", data.as_ref().map_mem(|x| x.len()))]
+    #[debug("{:?}", data.as_ref().map_mem(|x| x.len()).map_file(|f| f.size))]
     pub data: MemOrFile<Bytes, FileAndSize<T>>,
     /// outboard part, which can be in memory or on disk.
-    #[debug("{:?}", outboard.as_ref().map_mem(|x| x.len()))]
+    #[debug("{:?}", outboard.as_ref().map_mem(|x| x.len()).map_file(|f| f.size))]
     pub outboard: MemOrFile<Bytes, FileAndSize<T>>,
 }
 

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -2438,9 +2438,7 @@ where
         let mut info = None;
         tracing::trace!("on_complete({})", hash.to_hex());
         entry
-            // TODO: this errors on edition 2024, it should be changed to
-            // an async closure as they are now stable
-            .transform(|state| async {
+            .transform(async |state| {
                 tracing::trace!("on_complete transform {:?}", state);
                 let entry = match complete_storage(
                     state,

--- a/src/store/fs/test_support.rs
+++ b/src/store/fs/test_support.rs
@@ -102,7 +102,7 @@ impl Store {
     }
 }
 
-impl StoreInner {
+impl<T> StoreInner<T> {
     #[cfg(test)]
     async fn entry_state(&self, hash: Hash) -> OuterResult<EntryStateResponse> {
         let (tx, rx) = oneshot::channel();

--- a/src/store/fs/test_support.rs
+++ b/src/store/fs/test_support.rs
@@ -150,7 +150,7 @@ pub(crate) struct EntryStateResponse {
     pub db: Option<EntryState<Vec<u8>>>,
 }
 
-impl ActorState {
+impl<T> ActorState<T> {
     pub(super) fn get_full_entry_state(
         &mut self,
         tables: &impl ReadableTables,

--- a/src/store/fs/tests.rs
+++ b/src/store/fs/tests.rs
@@ -50,7 +50,7 @@ pub fn to_stream(
         .boxed()
 }
 
-async fn create_test_db() -> (tempfile::TempDir, Store) {
+async fn create_test_db() -> (tempfile::TempDir, Store<FileSystemPersistence>) {
     let _ = tracing_subscriber::fmt::try_init();
     let testdir = tempfile::tempdir().unwrap();
     let db_path = testdir.path().join("db.redb");
@@ -59,7 +59,9 @@ async fn create_test_db() -> (tempfile::TempDir, Store) {
         batch: Default::default(),
         inline: Default::default(),
     };
-    let db = Store::new(db_path, options).await.unwrap();
+    let db = Store::new(db_path, options, FileSystemPersistence)
+        .await
+        .unwrap();
     (testdir, db)
 }
 
@@ -788,7 +790,9 @@ async fn actor_store_smoke() {
         batch: Default::default(),
         inline: Default::default(),
     };
-    let db = Store::new(db_path, options).await.unwrap();
+    let db = Store::new(db_path, options, FileSystemPersistence)
+        .await
+        .unwrap();
     db.dump().await.unwrap();
     let data = random_test_data(1024 * 1024);
     #[allow(clippy::single_range_in_vec_init)]

--- a/src/store/fs/validate.rs
+++ b/src/store/fs/validate.rs
@@ -12,7 +12,7 @@ use crate::{
     util::progress::BoxedProgressSender,
 };
 
-impl ActorState {
+impl<T> ActorState<T> {
     //! This performs a full consistency check. Eventually it will also validate
     //! file content again, but that part is not yet implemented.
     //!

--- a/src/store/fs/validate.rs
+++ b/src/store/fs/validate.rs
@@ -5,14 +5,17 @@ use redb::ReadableTable;
 
 use super::{
     raw_outboard_size, tables::Tables, ActorResult, ActorState, DataLocation, EntryState, Hash,
-    OutboardLocation,
+    OutboardLocation, Persistence,
 };
 use crate::{
     store::{fs::tables::BaoFilePart, ConsistencyCheckProgress, ReportLevel},
     util::progress::BoxedProgressSender,
 };
 
-impl<T> ActorState<T> {
+impl<T> ActorState<T>
+where
+    T: Persistence,
+{
     //! This performs a full consistency check. Eventually it will also validate
     //! file content again, but that part is not yet implemented.
     //!

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,6 +22,7 @@ pub mod progress;
 pub use mem_or_file::{FileAndSize, MemOrFile};
 mod sparse_mem_file;
 pub use sparse_mem_file::SparseMemFile;
+pub mod callback_lock;
 pub mod local_pool;
 
 #[cfg(test)]

--- a/src/util.rs
+++ b/src/util.rs
@@ -19,7 +19,7 @@ pub mod fs;
 pub mod io;
 mod mem_or_file;
 pub mod progress;
-pub use mem_or_file::MemOrFile;
+pub use mem_or_file::{FileAndSize, MemOrFile};
 mod sparse_mem_file;
 pub use sparse_mem_file::SparseMemFile;
 pub mod local_pool;

--- a/src/util/callback_lock.rs
+++ b/src/util/callback_lock.rs
@@ -1,0 +1,77 @@
+//! This module defines a wrapper around a [`tokio::sync::RwLock`] that runs a callback
+//! After any write operation occurs
+
+use std::future::Future;
+
+/// A wrapper over a [`tokio::sync::RwLock`] that executes a callback function after
+/// the write guard is dropped
+#[derive(derive_more::Debug)]
+pub struct CallbackLock<T, F> {
+    inner: tokio::sync::RwLock<T>,
+    #[debug(skip)]
+    callback: F,
+}
+
+/// the wrapper type over a [tokio::sync::RwLockWriteGuard]
+#[derive(Debug)]
+pub struct CallbackLockWriteGuard<'a, T, F: Fn(&T)> {
+    inner: tokio::sync::RwLockWriteGuard<'a, T>,
+    callback: &'a F,
+}
+
+impl<T, F: Fn(&T)> std::ops::Deref for CallbackLockWriteGuard<'_, T, F> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl<T, F: Fn(&T)> std::ops::DerefMut for CallbackLockWriteGuard<'_, T, F> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.inner
+    }
+}
+
+impl<T, F: Fn(&T)> Drop for CallbackLockWriteGuard<'_, T, F> {
+    fn drop(&mut self) {
+        (self.callback)(&*self.inner);
+    }
+}
+
+impl<T, F> CallbackLock<T, F>
+where
+    F: Fn(&T),
+{
+    /// create a new instance of the lock from a value
+    /// and the callback to evaluate when a write guard is dropped
+    pub fn new(val: T, callback: F) -> Self {
+        CallbackLock {
+            inner: tokio::sync::RwLock::new(val),
+            callback,
+        }
+    }
+
+    /// return an instance of the write guard
+    pub async fn write(&self) -> CallbackLockWriteGuard<'_, T, F> {
+        let guard = self.inner.write().await;
+
+        CallbackLockWriteGuard {
+            inner: guard,
+            callback: &self.callback,
+        }
+    }
+
+    /// return the [tokio::sync::RwLockReadGuard]
+    /// this will not invoke the callback
+    pub fn read(&self) -> impl Future<Output = tokio::sync::RwLockReadGuard<'_, T>> {
+        self.inner.read()
+    }
+
+    /// try to synchronously acquire a read lock
+    pub fn try_read(
+        &self,
+    ) -> Result<tokio::sync::RwLockReadGuard<'_, T>, tokio::sync::TryLockError> {
+        self.inner.try_read()
+    }
+}

--- a/src/util/mem_or_file.rs
+++ b/src/util/mem_or_file.rs
@@ -14,9 +14,19 @@ pub enum MemOrFile<M, F> {
     File(F),
 }
 
+/// A struct which represents a handle to some file which
+/// is _not_ in memory and its size
+#[derive(derive_more::Debug)]
+pub struct FileAndSize<T> {
+    /// the generic file type
+    pub file: T,
+    /// the size in bytes of the file
+    pub size: u64,
+}
+
 /// Helper methods for a common way to use MemOrFile, where the memory part is something
 /// like a slice, and the file part is a tuple consisiting of path or file and size.
-impl<M, F> MemOrFile<M, (F, u64)>
+impl<M, F> MemOrFile<M, FileAndSize<F>>
 where
     M: AsRef<[u8]>,
 {
@@ -24,7 +34,7 @@ where
     pub fn size(&self) -> u64 {
         match self {
             MemOrFile::Mem(mem) => mem.as_ref().len() as u64,
-            MemOrFile::File((_, size)) => *size,
+            MemOrFile::File(FileAndSize { file: _, size }) => *size,
         }
     }
 }

--- a/src/util/mem_or_file.rs
+++ b/src/util/mem_or_file.rs
@@ -1,4 +1,4 @@
-use std::{fs::File, io};
+use std::{fs::File, future::Future, io};
 
 use bao_tree::io::sync::{ReadAt, Size};
 use bytes::Bytes;
@@ -38,9 +38,11 @@ impl<T> FileAndSize<T> {
         U::Output: Send + 'static,
     {
         let FileAndSize { file, size } = self;
-        FileAndSize {
-            file: f(file).await,
-            size,
+        async move {
+            FileAndSize {
+                file: f(file).await,
+                size,
+            }
         }
     }
 }

--- a/tests/gc.rs
+++ b/tests/gc.rs
@@ -22,8 +22,8 @@ use iroh_blobs::{
     net_protocol::Blobs,
     rpc::client::{blobs, tags},
     store::{
-        bao_tree, BaoBatchWriter, ConsistencyCheckProgress, EntryStatus, GcConfig, MapEntryMut,
-        MapMut, ReportLevel, Store,
+        bao_tree, fs::FileSystemPersistence, BaoBatchWriter, ConsistencyCheckProgress, EntryStatus,
+        GcConfig, MapEntryMut, MapMut, ReportLevel, Store,
     },
     util::{
         progress::{AsyncChannelProgressSender, ProgressSender as _},
@@ -127,7 +127,7 @@ async fn persistent_node(
     path: PathBuf,
     gc_period: Duration,
 ) -> (
-    Node<iroh_blobs::store::fs::Store>,
+    Node<iroh_blobs::store::fs::Store<FileSystemPersistence>>,
     async_channel::Receiver<()>,
 ) {
     let store = iroh_blobs::store::fs::Store::load(path).await.unwrap();

--- a/tests/rpc.rs
+++ b/tests/rpc.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "test")]
 use std::{net::SocketAddr, path::PathBuf, vec};
 
-use iroh_blobs::net_protocol::Blobs;
+use iroh_blobs::{net_protocol::Blobs, store::fs::FileSystemPersistence};
 use quic_rpc::client::QuinnConnector;
 use tempfile::TempDir;
 use testresult::TestResult;
@@ -14,7 +14,7 @@ type BlobsClient = iroh_blobs::rpc::client::blobs::Client<QC>;
 #[derive(Debug)]
 pub struct Node {
     pub router: iroh::protocol::Router,
-    pub blobs: Blobs<iroh_blobs::store::fs::Store>,
+    pub blobs: Blobs<iroh_blobs::store::fs::Store<FileSystemPersistence>>,
     pub rpc_task: AbortOnDropHandle<()>,
 }
 

--- a/tests/tags.rs
+++ b/tests/tags.rs
@@ -8,6 +8,7 @@ use iroh_blobs::{
         client::tags::{self, TagInfo},
         proto::RpcService,
     },
+    store::fs::FileSystemPersistence,
     Hash, HashAndFormat,
 };
 use testresult::TestResult;
@@ -142,7 +143,7 @@ async fn tags_smoke_mem() -> TestResult<()> {
 async fn tags_smoke_fs() -> TestResult<()> {
     let td = tempfile::tempdir()?;
     let endpoint = Endpoint::builder().bind().await?;
-    let blobs = Blobs::persistent(td.path().join("blobs.db"))
+    let blobs = Blobs::persistent(td.path(), td.path().join("blobs.db"), FileSystemPersistence)
         .await?
         .build(&endpoint);
     let client = blobs.client();


### PR DESCRIPTION
## Description

This MR introduces a `Persistence` trait which abstracts away the persistence layer for `Completed` bao files. This means that you can BYO persistence impl to the current fs store (e.g. S3).

## Breaking Changes

The external facing breaking changes are mostly around the "asyncification" of certain trait methods. I will update this section in more detail later.

## Notes & open questions

This is still a draft MR I am just looking for feedback on the general approach before I clean things up a bit more. e.g. There are some places that can panic right now

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
