### PR TITLE
chore: Fix redb version to the latest version that uses edition 2021

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ quic-rpc = { version = "0.19", optional = true }
 quic-rpc-derive = { version = "0.19", optional = true }
 rand = "0.8"
 range-collections = "0.4.0"
-redb = { version = "2.2.0", optional = true }
+redb = { version = "=2.4", optional = true }
 reflink-copy = { version = "0.1.8", optional = true }
 self_cell = "1.0.1"
 serde = { version = "1", features = ["derive"] }

--- a/deny.toml
+++ b/deny.toml
@@ -34,6 +34,7 @@ ignore = [
   "RUSTSEC-2024-0370", # unmaintained, no upgrade available
   "RUSTSEC-2024-0384", # unmaintained, no upgrade available
   "RUSTSEC-2024-0436", # unmaintained paste
+  "RUSTSEC-2023-0089", # unmaintained, no upgrade available yet
 ]
 
 [sources]


### PR DESCRIPTION
## Description

We had some issues with the latest redb using edition 2024. This restricts redb to the latest version that uses edition 2021.

## Breaking Changes

None

## Notes & open questions

Should we do a range restriction so people would get 2.4.1 if it gets released?

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
