### PR TITLE
fix: create parent dir when exporting from mem store

### DIFF
--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -745,6 +745,15 @@ async fn export_path_impl(
     tx: &mut mpsc::Sender<ExportProgressItem>,
 ) -> io::Result<()> {
     let ExportPathRequest { target, .. } = cmd;
+    if !target.is_absolute() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidInput,
+            "path is not absolute",
+        ));
+    }
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
     // todo: for partial entries make sure to only write the part that is actually present
     let mut file = std::fs::File::create(target)?;
     let size = entry.0.state.borrow().size();


### PR DESCRIPTION
## Description

The `fs` store already created the parent dir of the path passed to `Blobs::export`, but the `mem` store didn't. This copies some lines from the `fs` store to the `mem` store to also create the parent dir there.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
