### PR TITLE
chore: Remove unused dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1188,15 +1188,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashlink"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
-dependencies = [
- "hashbrown",
-]
-
-[[package]]
 name = "heapless"
 version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1730,10 +1721,8 @@ dependencies = [
  "clap",
  "data-encoding",
  "derive_more 2.0.1",
- "futures-buffered",
  "futures-lite",
  "genawaiter",
- "hashlink",
  "hex",
  "iroh",
  "iroh-base",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,6 @@ iroh-base = "0.90"
 reflink-copy = "0.1.24"
 irpc = { version = "0.5.0", features = ["rpc", "quinn_endpoint_setup", "message_spans", "stream", "derive"], default-features = false }
 iroh-metrics = { version = "0.35" }
-hashlink = "0.10.0"
-futures-buffered = "0.2.11"
 
 [dev-dependencies]
 clap = { version = "4.5.31", features = ["derive"] }


### PR DESCRIPTION
## Description

Lose some non-used deps. Futures-buffered is reexported by n0-future, as I learned yesterday

## Breaking Changes

None

## Notes & open questions

None

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
