### PR TITLE
docs: Update the transfer example to iroh 0.90

### DIFF
--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -56,12 +56,13 @@ async fn main() -> anyhow::Result<()> {
             let abs_path = std::path::absolute(filename)?;
             let ticket: BlobTicket = ticket.parse()?;
 
-            println!("Starting download.");
-
             // For receiving files, we create a "downloader" that allows us to fetch files
             // from other nodes via iroh connections
-            store
-                .downloader(&endpoint)
+            let downloader = store.downloader(&endpoint);
+
+            println!("Starting download.");
+
+            downloader
                 .download(ticket.hash(), Some(ticket.node_addr().node_id))
                 .await?;
 

--- a/examples/transfer.rs
+++ b/examples/transfer.rs
@@ -1,0 +1,113 @@
+use std::path::PathBuf;
+
+use anyhow::Result;
+use iroh::{protocol::Router, Endpoint};
+use iroh_blobs::{
+    api::blobs::{AddPathOptions, ExportMode, ExportOptions, ImportMode},
+    net_protocol::Blobs,
+    store::mem::MemStore,
+    ticket::BlobTicket,
+    BlobFormat,
+};
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Create an endpoint, it allows creating and accepting
+    // connections in the iroh p2p world
+    let endpoint = Endpoint::builder().discovery_n0().bind().await?;
+    // We initialize an in-memory backing store for iroh-blobs
+    let store = MemStore::new();
+    // Then we initialize a struct that can accept blobs requests over iroh connections
+    let blobs = Blobs::new(&store, endpoint.clone(), None);
+
+    // Grab all passed in arguments, the first one is the binary itself, so we skip it.
+    let args: Vec<String> = std::env::args().skip(1).collect();
+    // Convert to &str, so we can pattern-match easily:
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+
+    match arg_refs.as_slice() {
+        ["send", filename] => {
+            // For sending files we build a router that accepts blobs connections & routes them
+            // to the blobs protocol.
+            let router = Router::builder(endpoint)
+                .accept(iroh_blobs::ALPN, blobs)
+                .spawn();
+
+            let filename: PathBuf = filename.parse()?;
+            let abs_path = std::path::absolute(&filename)?;
+
+            println!("Hashing file.");
+
+            // When we import a blob, we get back a tag that refers to said blob in the store
+            // and allows us to control when/if it gets garbage-collected
+            let tag = store
+                .blobs()
+                .add_path_with_opts(AddPathOptions {
+                    path: abs_path,
+                    format: BlobFormat::Raw,
+                    mode: ImportMode::TryReference,
+                })
+                .await?;
+
+            let node_id = router.endpoint().node_id();
+            let ticket = BlobTicket::new(node_id.into(), tag.hash, tag.format);
+
+            println!("File hashed. Fetch this file by running:");
+            println!(
+                "cargo run --example transfer -- receive {ticket} {}",
+                filename.display()
+            );
+
+            tokio::signal::ctrl_c().await?;
+
+            // Gracefully shut down the node
+            println!("Shutting down.");
+            router.shutdown().await?;
+        }
+        ["receive", ticket, filename] => {
+            // For receiving files, we create a "downloader" that allows us to fetch files
+            // from other nodes via iroh connections
+            let downloader = store.downloader(&endpoint);
+
+            let filename: PathBuf = filename.parse()?;
+            let abs_path = std::path::absolute(filename)?;
+            let ticket: BlobTicket = ticket.parse()?;
+
+            println!("Starting download.");
+
+            downloader
+                .download(ticket.hash(), Some(ticket.node_addr().node_id))
+                .await?;
+
+            println!("Finished download.");
+            println!("Copying to destination.");
+
+            store
+                .blobs()
+                .export_with_opts(ExportOptions {
+                    hash: ticket.hash(),
+                    mode: ExportMode::TryReference,
+                    target: abs_path,
+                })
+                .await?;
+
+            println!("Finished copying.");
+
+            // Gracefully shut down the node
+            println!("Shutting down.");
+            endpoint.close().await;
+        }
+        _ => {
+            println!("Couldn't parse command line arguments: {args:?}");
+            println!("Usage:");
+            println!("    # to send:");
+            println!("    cargo run --example transfer -- send [FILE]");
+            println!("    # this will print a ticket.");
+            println!();
+            println!("    # to receive:");
+            println!("    cargo run --example transfer -- receive [TICKET] [FILE]");
+        }
+    }
+
+    Ok(())
+}

--- a/src/api/downloader.rs
+++ b/src/api/downloader.rs
@@ -364,7 +364,7 @@ impl Downloader {
         self.download_with_opts(DownloadOptions {
             request,
             providers,
-            strategy: SplitStrategy::Split,
+            strategy: SplitStrategy::None,
         })
     }
 


### PR DESCRIPTION
## Description

Revives the [old transfer example](https://github.com/n0-computer/iroh-blobs/blob/8a975ecda8bca5e8988db911857012e6817b456e/examples/transfer.rs) so we can use it on the https://www.iroh.computer/docs/quickstart page

## Notes & open questions

Also fixes a bug.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
