### PR TITLE
docs: fix repo link in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 description = "content-addressed blobs for iroh"
 license = "MIT OR Apache-2.0"
 authors = ["dignifiedquire <me@dignifiedquire.com>", "n0 team"]
-repository = "https://github.com/n0-computer/blobs2"
+repository = "https://github.com/n0-computer/iroh-blobs"
 keywords = ["hashing", "quic", "blake3", "streaming"]
 
 # Sadly this also needs to be updated in .github/workflows/ci.yml


### PR DESCRIPTION
# Description

This updates the repository link from the old/temporary `blobs2` repo to `iroh-blobs`.