### PR TITLE
fix: Hide the xxx_sink variants from the public API

### DIFF
--- a/src/api/remote.rs
+++ b/src/api/remote.rs
@@ -499,7 +499,7 @@ impl Remote {
     /// is the aggregated number of downloaded payload bytes in the request.
     ///
     /// This will return the stats of the download.
-    pub async fn fetch_sink(
+    pub(crate) async fn fetch_sink(
         &self,
         mut conn: impl GetConnection,
         content: impl Into<HashAndFormat>,
@@ -573,7 +573,7 @@ impl Remote {
     /// Push the given blob or hash sequence to a remote node.
     ///
     /// Note that many nodes will reject push requests. Also, this is an experimental feature for now.
-    pub async fn execute_push_sink(
+    pub(crate) async fn execute_push_sink(
         &self,
         conn: Connection,
         request: PushRequest,
@@ -654,7 +654,7 @@ impl Remote {
     /// This will download the data again even if the data is locally present.
     ///
     /// This will return the stats of the download.
-    pub async fn execute_get_sink(
+    pub(crate) async fn execute_get_sink(
         &self,
         conn: Connection,
         request: GetRequest,


### PR DESCRIPTION
## Description

These functions are internal and have no business being in the public API, I think

## Breaking Changes

Removes
- api::remote::Remote::fetch_sink
- api::remote::Remote::execute_push_sink
- api::remote::Remote::execute_get_sink

## Notes & open questions

Note: maybe we need to expose them at some point, but currently I don't see the need, and in any case the Sink trait is not exposed, so nobody can use them anyway at this time!

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
