### PR TITLE
feat: Add back builder for blobs protocol

### DIFF
--- a/examples/custom-protocol.rs
+++ b/examples/custom-protocol.rs
@@ -100,7 +100,7 @@ async fn listen(text: Vec<String>) -> Result<()> {
         proto.insert_and_index(text).await?;
     }
     // Build the iroh-blobs protocol handler, which is used to download blobs.
-    let blobs = BlobsProtocol::new(&store, endpoint.clone(), None);
+    let blobs = BlobsProtocol::builder(&store).build(&endpoint);
 
     // create a router that handles both our custom protocol and the iroh-blobs protocol.
     let node = Router::builder(endpoint)

--- a/examples/mdns-discovery.rs
+++ b/examples/mdns-discovery.rs
@@ -68,7 +68,7 @@ async fn accept(path: &Path) -> Result<()> {
         .await?;
     let builder = Router::builder(endpoint.clone());
     let store = MemStore::new();
-    let blobs = BlobsProtocol::new(&store, endpoint.clone(), None);
+    let blobs = BlobsProtocol::builder(&store).build(&endpoint);
     let builder = builder.accept(iroh_blobs::ALPN, blobs.clone());
     let node = builder.spawn();
 

--- a/examples/random_store.rs
+++ b/examples/random_store.rs
@@ -237,7 +237,9 @@ async fn provide(args: ProvideArgs) -> anyhow::Result<()> {
         .bind()
         .await?;
     let (dump_task, events_tx) = dump_provider_events(args.allow_push);
-    let blobs = iroh_blobs::BlobsProtocol::new(&store, endpoint.clone(), Some(events_tx));
+    let blobs = iroh_blobs::BlobsProtocol::builder(&store)
+        .events(events_tx)
+        .build(&endpoint);
     let router = iroh::protocol::Router::builder(endpoint.clone())
         .accept(iroh_blobs::ALPN, blobs)
         .spawn();


### PR DESCRIPTION
## Description

We used to have a builder in iroh-blobs. This brings it back. It does not have as many options as the previous one, but there will be more, probably.

I left the BlobsProtocol::new public for now. We can make it private if the options become too many.

## Breaking Changes

None

## Notes & open questions

Make new private right now?

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
