### PR TITLE
feat: streaming ListTags rpc call

### DIFF
--- a/examples/expiring-tags.rs
+++ b/examples/expiring-tags.rs
@@ -73,7 +73,7 @@ async fn delete_expired_tags(blobs: &Store, prefix: &str, bulk: bool) -> anyhow:
         // find tags to delete one by one and then delete them
         //
         // this allows us to print the tags before deleting them
-        let mut tags = blobs.tags().list().await?;
+        let mut tags = blobs.tags().list().stream();
         let mut to_delete = Vec::new();
         while let Some(tag) = tags.next().await {
             let tag = tag?.name;
@@ -102,7 +102,7 @@ async fn delete_expired_tags(blobs: &Store, prefix: &str, bulk: bool) -> anyhow:
 
 async fn print_store_info(store: &Store) -> anyhow::Result<()> {
     let now = chrono::Utc::now();
-    let mut tags = store.tags().list().await?;
+    let mut tags = store.tags().list().stream();
     println!(
         "Current time: {}",
         now.to_rfc3339_opts(chrono::SecondsFormat::Secs, true)
@@ -112,7 +112,7 @@ async fn print_store_info(store: &Store) -> anyhow::Result<()> {
         let tag = tag?;
         println!("  {tag:?}");
     }
-    let mut blobs = store.list().stream().await?;
+    let mut blobs = store.list().stream();
     println!("Blobs:");
     while let Some(item) = blobs.next().await {
         println!("  {}", item?);

--- a/src/api/blobs.rs
+++ b/src/api/blobs.rs
@@ -866,7 +866,7 @@ impl IrpcStreamItem for ListBlobsItem {
     fn into_result_opt(self) -> Option<Result<Hash, super::Error>> {
         match self {
             Self::Item(hash) => Some(Ok(hash)),
-            Self::Error(e) => Some(Err(e.into())),
+            Self::Error(e) => Some(Err(e)),
             Self::Done => None,
         }
     }
@@ -874,7 +874,7 @@ impl IrpcStreamItem for ListBlobsItem {
     fn from_result(item: std::result::Result<Hash, super::Error>) -> Self {
         match item {
             Ok(hash) => Self::Item(hash),
-            Err(e) => Self::Error(e.into()),
+            Err(e) => Self::Error(e),
         }
     }
 

--- a/src/api/proto.rs
+++ b/src/api/proto.rs
@@ -89,7 +89,7 @@ impl HashSpecific for CreateTagMsg {
 #[rpc_requests(message = Command, alias = "Msg")]
 #[derive(Debug, Serialize, Deserialize)]
 pub enum Request {
-    #[rpc(tx = mpsc::Sender<super::Result<Hash>>)]
+    #[rpc(tx = mpsc::Sender<ListBlobsItem>)]
     ListBlobs(ListRequest),
     #[rpc(tx = oneshot::Sender<Scope>, rx = mpsc::Receiver<BatchResponse>)]
     Batch(BatchRequest),
@@ -349,6 +349,13 @@ pub struct TagInfo {
     pub format: BlobFormat,
     /// Hash of the data
     pub hash: Hash,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ListBlobsItem {
+    Item(Hash),
+    Done,
+    Error(super::Error),
 }
 
 impl From<TagInfo> for HashAndFormat {

--- a/src/api/proto.rs
+++ b/src/api/proto.rs
@@ -15,6 +15,7 @@
 //! the much simpler memory store.
 use std::{
     fmt::{self, Debug},
+    future::{Future, IntoFuture},
     io,
     num::NonZeroU64,
     ops::{Bound, RangeBounds},
@@ -28,17 +29,25 @@ use bao_tree::{
     ChunkRanges,
 };
 use bytes::Bytes;
+use genawaiter::sync::Gen;
 use irpc::{
     channel::{mpsc, oneshot},
     rpc_requests,
 };
-use n0_future::Stream;
+use n0_future::{future, Stream};
 use range_collections::RangeSet2;
 use serde::{Deserialize, Serialize};
 pub(crate) mod bitfield;
 pub use bitfield::Bitfield;
 
-use crate::{store::util::Tag, util::temp_tag::TempTag, BlobFormat, Hash, HashAndFormat};
+use crate::{
+    store::util::Tag,
+    util::{
+        irpc::{IrpcReceiverFutExt, IrpcStreamItem},
+        temp_tag::TempTag,
+    },
+    BlobFormat, Hash, HashAndFormat,
+};
 
 pub(crate) trait HashSpecific {
     fn hash(&self) -> Hash;
@@ -113,7 +122,7 @@ pub enum Request {
     ImportPath(ImportPathRequest),
     #[rpc(tx = mpsc::Sender<ExportProgressItem>)]
     ExportPath(ExportPathRequest),
-    #[rpc(tx = oneshot::Sender<Vec<super::Result<TagInfo>>>)]
+    #[rpc(tx = mpsc::Sender<ListTagsItem>)]
     ListTags(ListTagsRequest),
     #[rpc(tx = oneshot::Sender<super::Result<()>>)]
     SetTag(SetTagRequest),
@@ -354,8 +363,110 @@ pub struct TagInfo {
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ListBlobsItem {
     Item(Hash),
-    Done,
     Error(super::Error),
+    Done,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum ListTagsItem {
+    Item(TagInfo),
+    Error(super::Error),
+    Done,
+}
+
+impl From<std::result::Result<TagInfo, super::Error>> for ListTagsItem {
+    fn from(item: std::result::Result<TagInfo, super::Error>) -> Self {
+        match item {
+            Ok(item) => ListTagsItem::Item(item),
+            Err(err) => ListTagsItem::Error(err),
+        }
+    }
+}
+
+impl IrpcStreamItem for ListTagsItem {
+    type Error = super::Error;
+    type Item = TagInfo;
+
+    fn into_result_opt(self) -> Option<Result<TagInfo, super::Error>> {
+        match self {
+            ListTagsItem::Item(item) => Some(Ok(item)),
+            ListTagsItem::Done => None,
+            ListTagsItem::Error(err) => Some(Err(err)),
+        }
+    }
+
+    fn from_result(item: std::result::Result<TagInfo, super::Error>) -> Self {
+        match item {
+            Ok(i) => Self::Item(i),
+            Err(e) => Self::Error(e.into()),
+        }
+    }
+
+    fn done() -> Self {
+        Self::Done
+    }
+}
+
+pub struct ListTagsProgress {
+    inner: future::Boxed<irpc::Result<mpsc::Receiver<ListTagsItem>>>,
+}
+
+impl IntoFuture for ListTagsProgress {
+    fn into_future(self) -> Self::IntoFuture {
+        Box::pin(self.inner.try_collect())
+    }
+
+    type IntoFuture = future::Boxed<Self::Output>;
+
+    type Output = super::Result<Vec<TagInfo>>;
+}
+
+impl ListTagsProgress {
+    pub(super) fn new(
+        fut: impl Future<Output = irpc::Result<mpsc::Receiver<ListTagsItem>>> + Send + 'static,
+    ) -> Self {
+        Self {
+            inner: Box::pin(fut),
+        }
+    }
+
+    pub fn stream(self) -> impl Stream<Item = super::Result<TagInfo>> {
+        Gen::new(|co| async move {
+            let mut rx = match self.inner.await {
+                Ok(rx) => rx,
+                Err(err) => {
+                    co.yield_(Err(super::Error::from(err))).await;
+                    return;
+                }
+            };
+            loop {
+                match rx.recv().await {
+                    Ok(Some(ListTagsItem::Item(item))) => {
+                        co.yield_(Ok(item)).await;
+                    }
+                    Ok(Some(ListTagsItem::Done)) => {
+                        break;
+                    }
+                    Ok(Some(ListTagsItem::Error(err))) => {
+                        co.yield_(Err(err.into())).await;
+                        break;
+                    }
+                    Ok(None) => {
+                        co.yield_(Err(super::Error::Io(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "stream ended",
+                        ))))
+                        .await;
+                        break;
+                    }
+                    Err(cause) => {
+                        co.yield_(Err(super::Error::from(cause))).await;
+                        break;
+                    }
+                }
+            }
+        })
+    }
 }
 
 impl From<TagInfo> for HashAndFormat {

--- a/src/api/tags.rs
+++ b/src/api/tags.rs
@@ -3,7 +3,7 @@
 //! The main entry point is the [`Tags`] struct.
 use std::ops::RangeBounds;
 
-use n0_future::{Stream, StreamExt};
+use n0_future::StreamExt;
 use ref_cast::RefCast;
 use tracing::trace;
 
@@ -17,7 +17,7 @@ use super::{
     ApiClient, Tag, TempTag,
 };
 use crate::{
-    api::proto::{ListTagsProgress, ListTempTagsRequest},
+    api::proto::{ListTagsProgress, ListTempTagsProgress, ListTempTagsRequest},
     HashAndFormat,
 };
 
@@ -33,11 +33,10 @@ impl Tags {
         Self::ref_cast(sender)
     }
 
-    pub async fn list_temp_tags(&self) -> irpc::Result<impl Stream<Item = HashAndFormat>> {
+    pub fn list_temp_tags(&self) -> ListTempTagsProgress {
         let options = ListTempTagsRequest;
         trace!("{:?}", options);
-        let res = self.client.rpc(options).await?;
-        Ok(n0_future::stream::iter(res))
+        ListTempTagsProgress::new(self.client.server_streaming(options, 32))
     }
 
     /// List all tags with options.

--- a/src/api/tags.rs
+++ b/src/api/tags.rs
@@ -16,7 +16,10 @@ use super::{
     proto::{CreateTempTagRequest, Scope},
     ApiClient, Tag, TempTag,
 };
-use crate::{api::proto::ListTempTagsRequest, HashAndFormat};
+use crate::{
+    api::proto::{ListTagsProgress, ListTempTagsRequest},
+    HashAndFormat,
+};
 
 /// The API for interacting with tags and temp tags.
 #[derive(Debug, Clone, ref_cast::RefCast)]
@@ -41,21 +44,15 @@ impl Tags {
     ///
     /// This is the most flexible way to list tags. All the other list methods are just convenience
     /// methods that call this one with the appropriate options.
-    pub async fn list_with_opts(
-        &self,
-        options: ListOptions,
-    ) -> irpc::Result<impl Stream<Item = super::Result<TagInfo>>> {
+    pub fn list_with_opts(&self, options: ListOptions) -> ListTagsProgress {
         trace!("{:?}", options);
-        let res = self.client.rpc(options).await?;
-        Ok(n0_future::stream::iter(res))
+        ListTagsProgress::new(self.client.server_streaming(options, 32))
     }
 
     /// Get the value of a single tag
     pub async fn get(&self, name: impl AsRef<[u8]>) -> super::RequestResult<Option<TagInfo>> {
-        let mut stream = self
-            .list_with_opts(ListOptions::single(name.as_ref()))
-            .await?;
-        Ok(stream.next().await.transpose()?)
+        let progress = self.list_with_opts(ListOptions::single(name.as_ref()));
+        Ok(progress.stream().next().await.transpose()?)
     }
 
     pub async fn set_with_opts(&self, options: SetOptions) -> super::RequestResult<()> {
@@ -77,34 +74,27 @@ impl Tags {
     }
 
     /// List a range of tags
-    pub async fn list_range<R, E>(
-        &self,
-        range: R,
-    ) -> irpc::Result<impl Stream<Item = super::Result<TagInfo>>>
+    pub fn list_range<R, E>(&self, range: R) -> ListTagsProgress
     where
         R: RangeBounds<E>,
         E: AsRef<[u8]>,
     {
-        self.list_with_opts(ListOptions::range(range)).await
+        self.list_with_opts(ListOptions::range(range))
     }
 
     /// Lists all tags with the given prefix.
-    pub async fn list_prefix(
-        &self,
-        prefix: impl AsRef<[u8]>,
-    ) -> irpc::Result<impl Stream<Item = super::Result<TagInfo>>> {
+    pub fn list_prefix(&self, prefix: impl AsRef<[u8]>) -> ListTagsProgress {
         self.list_with_opts(ListOptions::prefix(prefix.as_ref()))
-            .await
     }
 
     /// Lists all tags.
-    pub async fn list(&self) -> irpc::Result<impl Stream<Item = super::Result<TagInfo>>> {
-        self.list_with_opts(ListOptions::all()).await
+    pub fn list(&self) -> ListTagsProgress {
+        self.list_with_opts(ListOptions::all())
     }
 
     /// Lists all tags with a hash_seq format.
-    pub async fn list_hash_seq(&self) -> irpc::Result<impl Stream<Item = super::Result<TagInfo>>> {
-        self.list_with_opts(ListOptions::hash_seq()).await
+    pub fn list_hash_seq(&self) -> ListTagsProgress {
+        self.list_with_opts(ListOptions::hash_seq())
     }
 
     /// Deletes a tag.

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -94,7 +94,6 @@ use entry_state::{DataLocation, OutboardLocation};
 use gc::run_gc;
 use import::{ImportEntry, ImportSource};
 use irpc::channel::mpsc;
-use meta::list_blobs;
 use n0_future::{future::yield_now, io};
 use nested_enum_utils::enum_conversions;
 use range_collections::range_set::RangeSetRange;
@@ -507,9 +506,7 @@ impl Actor {
             }
             Command::ListBlobs(cmd) => {
                 trace!("{cmd:?}");
-                if let Ok(snapshot) = self.db().snapshot(cmd.span.clone()).await {
-                    self.spawn(list_blobs(snapshot, cmd));
-                }
+                self.db().send(cmd.into()).await.ok();
             }
             Command::Batch(cmd) => {
                 trace!("{cmd:?}");

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -123,6 +123,7 @@ use crate::{
     },
     util::{
         channel::oneshot,
+        irpc::MpscSenderExt,
         temp_tag::{TagDrop, TempTag, TempTagScope, TempTags},
         ChunkRangesExt,
     },
@@ -520,7 +521,7 @@ impl Actor {
             Command::ListTempTags(cmd) => {
                 trace!("{cmd:?}");
                 let tts = self.temp_tags.list();
-                cmd.tx.send(tts).await.ok();
+                cmd.tx.forward_iter(tts.into_iter().map(Ok)).await.ok();
             }
             Command::ImportBytes(cmd) => {
                 trace!("{cmd:?}");
@@ -1417,13 +1418,13 @@ impl FsStore {
 #[cfg(test)]
 pub mod tests {
     use core::panic;
-    use std::collections::{HashMap, HashSet};
+    use std::{collections::HashMap, future::IntoFuture};
 
     use bao_tree::{
         io::{outboard::PreOrderMemOutboard, round_up_to_chunks_groups},
         ChunkRanges,
     };
-    use n0_future::{stream, Stream, StreamExt};
+    use n0_future::{stream, Stream};
     use testresult::TestResult;
     use walkdir::WalkDir;
 
@@ -1973,23 +1974,13 @@ pub mod tests {
         let batch = store.blobs().batch().await?;
         let tt1 = batch.temp_tag(Hash::new("foo")).await?;
         let tt2 = batch.add_slice("boo").await?;
-        let tts = store
-            .tags()
-            .list_temp_tags()
-            .await?
-            .collect::<HashSet<_>>()
-            .await;
+        let tts = store.tags().list_temp_tags().into_future().await?;
         assert!(tts.contains(tt1.hash_and_format()));
         assert!(tts.contains(tt2.hash_and_format()));
         drop(batch);
         store.sync_db().await?;
         store.wait_idle().await?;
-        let tts = store
-            .tags()
-            .list_temp_tags()
-            .await?
-            .collect::<HashSet<_>>()
-            .await;
+        let tts = store.tags().list_temp_tags().await?;
         // temp tag went out of scope, so it does not work anymore
         assert!(!tts.contains(tt1.hash_and_format()));
         assert!(!tts.contains(tt2.hash_and_format()));

--- a/src/store/fs/gc.rs
+++ b/src/store/fs/gc.rs
@@ -48,7 +48,7 @@ pub(super) async fn gc_mark_task(
     }
     let mut roots = HashSet::new();
     trace!("traversing tags");
-    let mut tags = store.tags().list().await?;
+    let mut tags = store.tags().list().stream();
     while let Some(tag) = tags.next().await {
         let info = tag?;
         trace!("adding root {:?} {:?}", info.name, info.hash_and_format());
@@ -85,7 +85,7 @@ async fn gc_sweep_task(
     live: &HashSet<Hash>,
     co: &Co<GcSweepEvent>,
 ) -> crate::api::Result<()> {
-    let mut blobs = store.blobs().list().stream().await?;
+    let mut blobs = store.blobs().list().stream();
     let mut count = 0;
     let mut batch = Vec::new();
     while let Some(hash) = blobs.next().await {

--- a/src/store/fs/gc.rs
+++ b/src/store/fs/gc.rs
@@ -55,10 +55,10 @@ pub(super) async fn gc_mark_task(
         roots.insert(info.hash_and_format());
     }
     trace!("traversing temp roots");
-    let mut tts = store.tags().list_temp_tags().await?;
+    let mut tts = store.tags().list_temp_tags().stream();
     while let Some(tt) = tts.next().await {
         trace!("adding temp root {:?}", tt);
-        roots.insert(tt);
+        roots.insert(tt?);
     }
     for HashAndFormat { hash, format } in roots {
         // we need to do this for all formats except raw

--- a/src/store/fs/meta/proto.rs
+++ b/src/store/fs/meta/proto.rs
@@ -5,11 +5,11 @@ use bytes::Bytes;
 use nested_enum_utils::enum_conversions;
 use tracing::Span;
 
-use super::{ActorResult, ReadOnlyTables};
+use super::ActorResult;
 use crate::{
     api::proto::{
-        BlobStatusMsg, ClearProtectedMsg, DeleteBlobsMsg, ProcessExitRequest, ShutdownMsg,
-        SyncDbMsg,
+        BlobStatusMsg, ClearProtectedMsg, DeleteBlobsMsg, ListBlobsMsg, ProcessExitRequest,
+        ShutdownMsg, SyncDbMsg,
     },
     store::{fs::entry_state::EntryState, util::DD},
     util::channel::oneshot,
@@ -46,12 +46,6 @@ pub struct GetResult {
 #[derive(Debug)]
 pub struct Dump {
     pub tx: oneshot::Sender<anyhow::Result<()>>,
-    pub span: Span,
-}
-
-#[derive(Debug)]
-pub struct Snapshot {
-    pub(crate) tx: tokio::sync::oneshot::Sender<ReadOnlyTables>,
     pub span: Span,
 }
 
@@ -167,7 +161,7 @@ impl ReadWriteCommand {
 pub enum TopLevelCommand {
     SyncDb(SyncDbMsg),
     Shutdown(ShutdownMsg),
-    Snapshot(Snapshot),
+    ListBlobs(ListBlobsMsg),
 }
 
 impl TopLevelCommand {
@@ -181,7 +175,7 @@ impl TopLevelCommand {
         match self {
             Self::SyncDb(x) => x.parent_span_opt(),
             Self::Shutdown(x) => x.parent_span_opt(),
-            Self::Snapshot(x) => Some(&x.span),
+            Self::ListBlobs(x) => Some(&x.span),
         }
     }
 }

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -330,10 +330,15 @@ impl Actor {
                 let blobs = self.state.data.keys().cloned().collect::<Vec<Hash>>();
                 self.spawn(async move {
                     for blob in blobs {
-                        if tx.send(Ok(blob)).await.is_err() {
+                        if tx
+                            .send(api::proto::ListBlobsItem::Item(blob))
+                            .await
+                            .is_err()
+                        {
                             break;
                         }
                     }
+                    tx.send(api::proto::ListBlobsItem::Done).await.ok();
                 });
             }
             Command::BlobStatus(cmd) => {

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -324,7 +324,7 @@ impl Actor {
             Command::ListTempTags(cmd) => {
                 trace!("{cmd:?}");
                 let tts = self.temp_tags.list();
-                cmd.tx.send(tts).await.ok();
+                cmd.tx.forward_iter(tts.into_iter().map(Ok)).await.ok();
             }
             Command::ListBlobs(cmd) => {
                 let ListBlobsMsg { tx, .. } = cmd;

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -61,6 +61,7 @@ use crate::{
         HashAndFormat, IROH_BLOCK_SIZE,
     },
     util::{
+        irpc::MpscSenderExt,
         temp_tag::{TagDrop, TempTagScope, TempTags},
         ChunkRangesExt,
     },
@@ -297,7 +298,7 @@ impl Actor {
                         format: value.format,
                     })
                     .map(Ok);
-                tx.send(tags.collect()).await.ok();
+                tx.forward_iter(tags).await.ok();
             }
             Command::SetTag(SetTagMsg {
                 inner: SetTagRequest { name: tag, value },

--- a/src/store/readonly_mem.rs
+++ b/src/store/readonly_mem.rs
@@ -42,7 +42,7 @@ use crate::{
         ApiClient, TempTag,
     },
     store::{mem::CompleteStorage, IROH_BLOCK_SIZE},
-    util::ChunkRangesExt,
+    util::{irpc::MpscSenderExt, ChunkRangesExt},
     Hash,
 };
 
@@ -196,7 +196,7 @@ impl Actor {
                 cmd.tx.send(status).await.ok();
             }
             Command::ListTags(cmd) => {
-                cmd.tx.send(proto::ListTagsItem::Done).await.ok();
+                cmd.tx.forward_iter(std::iter::empty()).await.ok();
             }
             Command::SetTag(cmd) => {
                 cmd.tx

--- a/src/store/readonly_mem.rs
+++ b/src/store/readonly_mem.rs
@@ -36,8 +36,8 @@ use crate::{
         proto::{
             self, BlobStatus, Command, ExportBaoMsg, ExportBaoRequest, ExportPathMsg,
             ExportPathRequest, ExportRangesItem, ExportRangesMsg, ExportRangesRequest,
-            ImportBaoMsg, ImportByteStreamMsg, ImportBytesMsg, ImportPathMsg, ObserveMsg,
-            ObserveRequest, WaitIdleMsg,
+            ImportBaoMsg, ImportByteStreamMsg, ImportBytesMsg, ImportPathMsg, ListBlobsItem,
+            ObserveMsg, ObserveRequest, WaitIdleMsg,
         },
         ApiClient, TempTag,
     },
@@ -178,8 +178,9 @@ impl Actor {
                 let hashes: Vec<Hash> = self.data.keys().cloned().collect();
                 self.tasks.spawn(async move {
                     for hash in hashes {
-                        cmd.tx.send(Ok(hash)).await.ok();
+                        cmd.tx.send(ListBlobsItem::Item(hash)).await.ok();
                     }
+                    cmd.tx.send(ListBlobsItem::Done).await.ok();
                 });
             }
             Command::BlobStatus(cmd) => {

--- a/src/store/readonly_mem.rs
+++ b/src/store/readonly_mem.rs
@@ -205,7 +205,7 @@ impl Actor {
                     .ok();
             }
             Command::ListTempTags(cmd) => {
-                cmd.tx.send(Vec::new()).await.ok();
+                cmd.tx.forward_iter(std::iter::empty()).await.ok();
             }
             Command::SyncDb(cmd) => {
                 cmd.tx.send(Ok(())).await.ok();

--- a/src/store/readonly_mem.rs
+++ b/src/store/readonly_mem.rs
@@ -196,7 +196,7 @@ impl Actor {
                 cmd.tx.send(status).await.ok();
             }
             Command::ListTags(cmd) => {
-                cmd.tx.send(Vec::new()).await.ok();
+                cmd.tx.send(proto::ListTagsItem::Done).await.ok();
             }
             Command::SetTag(cmd) => {
                 cmd.tx

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,6 +4,7 @@ use bao_tree::{io::round_up_to_chunks, ChunkNum, ChunkRanges};
 use range_collections::{range_set::RangeSetEntry, RangeSet2};
 
 pub mod channel;
+pub mod irpc;
 pub(crate) mod temp_tag;
 pub mod serde {
     // Module that handles io::Error serialization/deserialization

--- a/src/util/irpc.rs
+++ b/src/util/irpc.rs
@@ -1,0 +1,171 @@
+use std::{future::Future, io};
+
+use genawaiter::sync::Gen;
+use irpc::{channel::mpsc, RpcMessage};
+use n0_future::{Stream, StreamExt};
+
+/// Trait for an enum that has three variants, item, error, and done.
+///
+/// This is very common for irpc stream items if you want to provide an explicit
+/// end of stream marker to make sure unsuccessful termination is not mistaken
+/// for successful end of stream.
+pub(crate) trait IrpcStreamItem: RpcMessage {
+    /// The error case of the item enum.
+    type Error;
+    /// The item case of the item enum.
+    type Item;
+    /// Converts the stream item into either None for end of stream, or a Result
+    /// containing the item or an error. Error is assumed as a termination, so
+    /// if you get error you won't get an additional end of stream marker.
+    fn into_result_opt(self) -> Option<Result<Self::Item, Self::Error>>;
+    /// Converts a result into the item enum.
+    fn from_result(item: std::result::Result<Self::Item, Self::Error>) -> Self;
+    /// Produces a done marker for the item enum.
+    fn done() -> Self;
+}
+
+pub(crate) trait MpscSenderExt<T: IrpcStreamItem>: Sized {
+    /// Forward a stream of items to the sender.
+    ///
+    /// This will convert items and errors into the item enum type, and add
+    /// a done marker if the stream ends without an error.
+    async fn forward_stream(
+        self,
+        stream: impl Stream<Item = std::result::Result<T::Item, T::Error>>,
+    ) -> std::result::Result<(), irpc::channel::SendError>;
+
+    /// Forward an iterator of items to the sender.
+    ///
+    /// This will convert items and errors into the item enum type, and add
+    /// a done marker if the iterator ends without an error.
+    async fn forward_iter(
+        self,
+        iter: impl Iterator<Item = std::result::Result<T::Item, T::Error>>,
+    ) -> std::result::Result<(), irpc::channel::SendError>;
+}
+
+impl<T> MpscSenderExt<T> for mpsc::Sender<T>
+where
+    T: IrpcStreamItem,
+{
+    async fn forward_stream(
+        self,
+        stream: impl Stream<Item = std::result::Result<T::Item, T::Error>>,
+    ) -> std::result::Result<(), irpc::channel::SendError> {
+        tokio::pin!(stream);
+        while let Some(item) = stream.next().await {
+            let done = item.is_err();
+            self.send(T::from_result(item)).await?;
+            if done {
+                return Ok(());
+            };
+        }
+        self.send(T::done()).await
+    }
+
+    async fn forward_iter(
+        self,
+        iter: impl Iterator<Item = std::result::Result<T::Item, T::Error>>,
+    ) -> std::result::Result<(), irpc::channel::SendError> {
+        for item in iter {
+            let done = item.is_err();
+            self.send(T::from_result(item)).await?;
+            if done {
+                return Ok(());
+            };
+        }
+        self.send(T::done()).await
+    }
+}
+
+pub(crate) trait IrpcReceiverFutExt<T: IrpcStreamItem> {
+    /// Collects the receiver returned by this future into a collection,
+    /// provided that we get a receiver and draining the receiver does not
+    /// produce any error items.
+    ///
+    /// The collection must implement Default and Extend<T::Item>.
+    /// Note that using this with a very large stream might use a lot of memory.
+    async fn try_collect<C, E>(self) -> std::result::Result<C, E>
+    where
+        C: Default + Extend<T::Item>,
+        E: From<T::Error>,
+        E: From<irpc::Error>,
+        E: From<irpc::channel::RecvError>;
+
+    /// Converts the receiver returned by this future into a stream of items,
+    /// where each item is either a successful item or an error.
+    ///
+    /// There will be at most one error item, which will terminate the stream.
+    /// If the future returns an error, the stream will yield that error as the
+    /// first item and then terminate.
+    fn into_stream<E>(self) -> impl Stream<Item = std::result::Result<T::Item, E>>
+    where
+        E: From<T::Error>,
+        E: From<irpc::Error>,
+        E: From<irpc::channel::RecvError>;
+}
+
+impl<T, F> IrpcReceiverFutExt<T> for F
+where
+    T: IrpcStreamItem,
+    F: Future<Output = std::result::Result<irpc::channel::mpsc::Receiver<T>, irpc::Error>>,
+{
+    async fn try_collect<C, E>(self) -> std::result::Result<C, E>
+    where
+        C: Default + Extend<T::Item>,
+        E: From<T::Error>,
+        E: From<irpc::Error>,
+        E: From<irpc::channel::RecvError>,
+    {
+        let mut items = C::default();
+        let mut stream = self.into_stream::<E>();
+        while let Some(item) = stream.next().await {
+            match item {
+                Ok(i) => items.extend(Some(i)),
+                Err(e) => return Err(E::from(e)),
+            }
+        }
+        Ok(items)
+    }
+
+    fn into_stream<E>(self) -> impl Stream<Item = std::result::Result<T::Item, E>>
+    where
+        E: From<T::Error>,
+        E: From<irpc::Error>,
+        E: From<irpc::channel::RecvError>,
+    {
+        Gen::new(move |co| async move {
+            let mut rx = match self.await {
+                Ok(rx) => rx,
+                Err(e) => {
+                    co.yield_(Err(E::from(e))).await;
+                    return;
+                }
+            };
+            loop {
+                match rx.recv().await {
+                    Ok(Some(item)) => match item.into_result_opt() {
+                        Some(Ok(i)) => co.yield_(Ok(i)).await,
+                        Some(Err(e)) => {
+                            co.yield_(Err(E::from(e))).await;
+                            break;
+                        }
+                        None => break,
+                    },
+                    Ok(None) => {
+                        co.yield_(Err(E::from(irpc::channel::RecvError::Io(io::Error::new(
+                            io::ErrorKind::UnexpectedEof,
+                            "unexpected end of stream",
+                        )))))
+                        .await;
+                        break;
+                    }
+                    Err(e) => {
+                        co.yield_(Err(E::from(e))).await;
+                        break;
+                    }
+                }
+            }
+        })
+    }
+}

--- a/src/util/irpc.rs
+++ b/src/util/irpc.rs
@@ -29,6 +29,7 @@ pub(crate) trait MpscSenderExt<T: IrpcStreamItem>: Sized {
     ///
     /// This will convert items and errors into the item enum type, and add
     /// a done marker if the stream ends without an error.
+    #[allow(dead_code)]
     async fn forward_stream(
         self,
         stream: impl Stream<Item = std::result::Result<T::Item, T::Error>>,
@@ -122,7 +123,7 @@ where
         while let Some(item) = stream.next().await {
             match item {
                 Ok(i) => items.extend(Some(i)),
-                Err(e) => return Err(E::from(e)),
+                Err(e) => return Err(e),
             }
         }
         Ok(items)

--- a/tests/tags.rs
+++ b/tests/tags.rs
@@ -5,20 +5,13 @@ use std::{
 
 use iroh_blobs::{
     api::{
-        self,
         tags::{TagInfo, Tags},
         Store,
     },
     store::{fs::FsStore, mem::MemStore},
     BlobFormat, Hash, HashAndFormat,
 };
-use n0_future::{Stream, StreamExt};
 use testresult::TestResult;
-
-async fn to_vec<T>(stream: impl Stream<Item = api::Result<T>>) -> api::Result<Vec<T>> {
-    let res = stream.collect::<Vec<_>>().await;
-    res.into_iter().collect::<api::Result<Vec<_>>>()
-}
 
 fn expected(tags: impl IntoIterator<Item = &'static str>) -> Vec<TagInfo> {
     tags.into_iter()
@@ -35,50 +28,40 @@ async fn set(tags: &Tags, names: impl IntoIterator<Item = &str>) -> TestResult<(
 
 async fn tags_smoke(tags: &Tags) -> TestResult<()> {
     set(tags, ["a", "b", "c", "d", "e"]).await?;
-    let stream = tags.list().await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list().await?;
     assert_eq!(res, expected(["a", "b", "c", "d", "e"]));
 
-    let stream = tags.list_range("b".."d").await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list_range("b".."d").await?;
     assert_eq!(res, expected(["b", "c"]));
 
-    let stream = tags.list_range("b"..).await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list_range("b"..).await?;
     assert_eq!(res, expected(["b", "c", "d", "e"]));
 
-    let stream = tags.list_range(.."d").await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list_range(.."d").await?;
     assert_eq!(res, expected(["a", "b", "c"]));
 
-    let stream = tags.list_range(..="d").await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list_range(..="d").await?;
     assert_eq!(res, expected(["a", "b", "c", "d"]));
 
     tags.delete_range("b"..).await?;
-    let stream = tags.list().await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list().await?;
     assert_eq!(res, expected(["a"]));
 
     tags.delete_range(..="a").await?;
-    let stream = tags.list().await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list().await?;
     assert_eq!(res, expected([]));
 
     set(tags, ["a", "aa", "aaa", "aab", "b"]).await?;
 
-    let stream = tags.list_prefix("aa").await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list_prefix("aa").await?;
     assert_eq!(res, expected(["aa", "aaa", "aab"]));
 
     tags.delete_prefix("aa").await?;
-    let stream = tags.list().await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list().await?;
     assert_eq!(res, expected(["a", "b"]));
 
     tags.delete_prefix("").await?;
-    let stream = tags.list().await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list().await?;
     assert_eq!(res, expected([]));
 
     set(tags, ["a", "b", "c"]).await?;
@@ -89,8 +72,7 @@ async fn tags_smoke(tags: &Tags) -> TestResult<()> {
     );
 
     tags.delete("b").await?;
-    let stream = tags.list().await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list().await?;
     assert_eq!(res, expected(["a", "c"]));
 
     assert_eq!(tags.get("b").await?, None);
@@ -100,8 +82,7 @@ async fn tags_smoke(tags: &Tags) -> TestResult<()> {
     tags.set("a", HashAndFormat::hash_seq(Hash::new("a")))
         .await?;
     tags.set("b", HashAndFormat::raw(Hash::new("b"))).await?;
-    let stream = tags.list_hash_seq().await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list_hash_seq().await?;
     assert_eq!(
         res,
         vec![TagInfo {
@@ -114,8 +95,7 @@ async fn tags_smoke(tags: &Tags) -> TestResult<()> {
     tags.delete_all().await?;
     set(tags, ["c"]).await?;
     tags.rename("c", "f").await?;
-    let stream = tags.list().await?;
-    let res = to_vec(stream).await?;
+    let res = tags.list().await?;
     assert_eq!(
         res,
         vec![TagInfo {


### PR DESCRIPTION
## Description

This makes the ListTags rpc call streaming instead of returning a single `Vec<TagInfo>`. Returning a Vec was the quickest to implement, but would be an issue if somebody had a giant number of tags, which we all know people will do eventually...

It also adds quite a bit of plumbing to deal with the very common case where you have an irpc stream item enum with 3 cases, item/error/done to provide an explicit marker for successful termination.

It also moves the handling of the only metadata call that requires a task - listblobs, into the metadata actor itself so the metadata actor is more self-contained. Unfortunately this means that the metadata actor also needs a JoinSet of tasks, but this will make it easier later to have the metadata db as a separate component for things like https://github.com/n0-computer/iroh-blobs/issues/84

## Breaking Changes

Changes the ListTags rpc return type.
Not sure what is wrong with the semver check, but there **are** breaking changes!

## Notes & open questions

Note: if the IrpcStreamItem stuff turns out useful enough I might move it into irpc and add some macros to make declaring these easier. But for now I don't want to do this since I don't want a genawaiter dependency in irpc, and I can't be bothered to manually write the into_stream state machine.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
