### PR TITLE
feat: let connection pool watch for connection close

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1683,7 +1683,7 @@ dependencies = [
  "iroh-quinn-proto",
  "iroh-quinn-udp",
  "iroh-relay",
- "n0-future",
+ "n0-future 0.1.3",
  "n0-snafu",
  "n0-watcher",
  "nested_enum_utils",
@@ -1758,7 +1758,7 @@ dependencies = [
  "iroh-quinn",
  "iroh-test",
  "irpc",
- "n0-future",
+ "n0-future 0.2.0",
  "n0-snafu",
  "nested_enum_utils",
  "postcard",
@@ -1900,7 +1900,7 @@ dependencies = [
  "iroh-quinn",
  "iroh-quinn-proto",
  "lru",
- "n0-future",
+ "n0-future 0.1.3",
  "n0-snafu",
  "nested_enum_utils",
  "num_enum",
@@ -1951,7 +1951,7 @@ dependencies = [
  "futures-util",
  "iroh-quinn",
  "irpc-derive",
- "n0-future",
+ "n0-future 0.1.3",
  "postcard",
  "rcgen",
  "rustls",
@@ -2174,6 +2174,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "n0-future"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89d7dd42bd0114c9daa9c4f2255d692a73bba45767ec32cf62892af6fe5d31f6"
+dependencies = [
+ "cfg_aliases",
+ "derive_more 1.0.0",
+ "futures-buffered",
+ "futures-lite",
+ "futures-util",
+ "js-sys",
+ "pin-project",
+ "send_wrapper",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
 name = "n0-snafu"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2193,7 +2214,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31462392a10d5ada4b945e840cbec2d5f3fee752b96c4b33eb41414d8f45c2a"
 dependencies = [
  "derive_more 1.0.0",
- "n0-future",
+ "n0-future 0.1.3",
  "snafu",
 ]
 
@@ -2319,7 +2340,7 @@ dependencies = [
  "iroh-quinn-udp",
  "js-sys",
  "libc",
- "n0-future",
+ "n0-future 0.1.3",
  "n0-watcher",
  "nested_enum_utils",
  "netdev",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3617,9 +3617,9 @@ dependencies = [
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bytes = { version = "1", features = ["serde"] }
 derive_more = { version = "2.0.1", features = ["from", "try_from", "into", "debug", "display", "deref", "deref_mut"] }
 futures-lite = "2.6.0"
 quinn = { package = "iroh-quinn", version = "0.14.0" }
-n0-future = "0.1.2"
+n0-future = "0.2.0"
 n0-snafu = "0.2.0"
 range-collections = { version = "0.4.6", features = ["serde"] }
 redb = { version = "=2.4" }

--- a/src/api/blobs/reader.rs
+++ b/src/api/blobs/reader.rs
@@ -221,6 +221,7 @@ mod tests {
 
     use super::*;
     use crate::{
+        protocol::ChunkRangesExt,
         store::{
             fs::{
                 tests::{create_n0_bao, test_data, INTERESTING_SIZES},
@@ -228,7 +229,6 @@ mod tests {
             },
             mem::MemStore,
         },
-        util::ChunkRangesExt,
     };
 
     async fn reader_smoke(blobs: &Blobs) -> TestResult<()> {

--- a/src/api/downloader.rs
+++ b/src/api/downloader.rs
@@ -442,7 +442,7 @@ async fn execute_get(
                 request: request.clone(),
             })
             .await?;
-        let conn = pool.connect(provider);
+        let conn = pool.get_or_connect(provider);
         let local = remote.local_for_request(request.clone()).await?;
         if local.is_complete() {
             return Ok(());

--- a/src/api/downloader.rs
+++ b/src/api/downloader.rs
@@ -4,23 +4,20 @@ use std::{
     fmt::Debug,
     future::{Future, IntoFuture},
     io,
-    ops::Deref,
     sync::Arc,
-    time::{Duration, SystemTime},
 };
 
 use anyhow::bail;
 use genawaiter::sync::Gen;
-use iroh::{endpoint::Connection, Endpoint, NodeId};
+use iroh::{Endpoint, NodeId};
 use irpc::{channel::mpsc, rpc_requests};
 use n0_future::{future, stream, BufferedStreamExt, Stream, StreamExt};
 use rand::seq::SliceRandom;
 use serde::{de::Error, Deserialize, Serialize};
-use tokio::{sync::Mutex, task::JoinSet};
-use tokio_util::time::FutureExt;
-use tracing::{info, instrument::Instrument, warn};
+use tokio::task::JoinSet;
+use tracing::instrument::Instrument;
 
-use super::{remote::GetConnection, Store};
+use super::Store;
 use crate::{
     protocol::{GetManyRequest, GetRequest},
     util::{
@@ -445,7 +442,7 @@ async fn execute_get(
                 request: request.clone(),
             })
             .await?;
-        let mut conn = pool.connect(provider);
+        let conn = pool.connect(provider);
         let local = remote.local_for_request(request.clone()).await?;
         if local.is_complete() {
             return Ok(());

--- a/src/api/remote.rs
+++ b/src/api/remote.rs
@@ -662,6 +662,8 @@ impl Remote {
     ) -> GetResult<Stats> {
         let store = self.store();
         let root = request.hash;
+        // I am cloning the connection, but it's fine because the original connection or ConnectionRef stays alive
+        // for the duration of the operation.
         let start = crate::get::fsm::start(conn.clone(), request, Default::default());
         let connected = start.next().await?;
         trace!("Getting header");

--- a/src/api/remote.rs
+++ b/src/api/remote.rs
@@ -1067,7 +1067,7 @@ mod tests {
 
     use crate::{
         api::blobs::Blobs,
-        protocol::{ChunkRangesSeq, GetRequest},
+        protocol::{ChunkRangesExt, ChunkRangesSeq, GetRequest},
         store::{
             fs::{
                 tests::{create_n0_bao, test_data, INTERESTING_SIZES},
@@ -1076,7 +1076,6 @@ mod tests {
             mem::MemStore,
         },
         tests::{add_test_hash_seq, add_test_hash_seq_incomplete},
-        util::ChunkRangesExt,
     };
 
     #[tokio::test]

--- a/src/get/request.rs
+++ b/src/get/request.rs
@@ -27,8 +27,7 @@ use super::{fsm, GetError, GetResult, Stats};
 use crate::{
     get::error::{BadRequestSnafu, LocalFailureSnafu},
     hashseq::HashSeq,
-    protocol::{ChunkRangesSeq, GetRequest},
-    util::ChunkRangesExt,
+    protocol::{ChunkRangesExt, ChunkRangesSeq, GetRequest},
     Hash, HashAndFormat,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub mod ticket;
 
 #[doc(hidden)]
 pub mod test;
-mod util;
+pub mod util;
 
 #[cfg(test)]
 mod tests;

--- a/src/protocol/range_spec.rs
+++ b/src/protocol/range_spec.rs
@@ -12,7 +12,7 @@ use bao_tree::{ChunkNum, ChunkRangesRef};
 use serde::{Deserialize, Serialize};
 use smallvec::{smallvec, SmallVec};
 
-pub use crate::util::ChunkRangesExt;
+use crate::protocol::ChunkRangesExt;
 
 static CHUNK_RANGES_EMPTY: OnceLock<ChunkRanges> = OnceLock::new();
 
@@ -511,7 +511,7 @@ mod tests {
     use proptest::prelude::*;
 
     use super::*;
-    use crate::util::ChunkRangesExt;
+    use crate::protocol::ChunkRangesExt;
 
     fn ranges(value_range: Range<u64>) -> impl Strategy<Value = ChunkRanges> {
         prop::collection::vec((value_range.clone(), value_range), 0..16).prop_map(|v| {

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -111,6 +111,7 @@ use crate::{
         },
         ApiClient,
     },
+    protocol::ChunkRangesExt,
     store::{
         fs::{
             bao_file::{
@@ -125,7 +126,6 @@ use crate::{
     util::{
         channel::oneshot,
         temp_tag::{TagDrop, TempTag, TempTagScope, TempTags},
-        ChunkRangesExt,
     },
 };
 mod bao_file;

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -56,14 +56,12 @@ use crate::{
         tags::TagInfo,
         ApiClient,
     },
+    protocol::ChunkRangesExt,
     store::{
         util::{SizeInfo, SparseMemFile, Tag},
         HashAndFormat, IROH_BLOCK_SIZE,
     },
-    util::{
-        temp_tag::{TagDrop, TempTagScope, TempTags},
-        ChunkRangesExt,
-    },
+    util::temp_tag::{TagDrop, TempTagScope, TempTags},
     BlobFormat, Hash,
 };
 

--- a/src/store/readonly_mem.rs
+++ b/src/store/readonly_mem.rs
@@ -41,8 +41,8 @@ use crate::{
         },
         ApiClient, TempTag,
     },
+    protocol::ChunkRangesExt,
     store::{mem::CompleteStorage, IROH_BLOCK_SIZE},
-    util::ChunkRangesExt,
     Hash,
 };
 

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,13 +1,9 @@
-use std::ops::{Bound, RangeBounds};
-
-use bao_tree::{io::round_up_to_chunks, ChunkNum, ChunkRanges};
-use range_collections::{range_set::RangeSetEntry, RangeSet2};
-
-pub mod channel;
-pub(crate) mod connection_pool;
+//! Utilities
+pub(crate) mod channel;
+pub mod connection_pool;
 pub(crate) mod temp_tag;
 
-pub mod serde {
+pub(crate) mod serde {
     // Module that handles io::Error serialization/deserialization
     pub mod io_error_serde {
         use std::{fmt, io};
@@ -218,74 +214,7 @@ pub mod serde {
     }
 }
 
-pub trait ChunkRangesExt {
-    fn last_chunk() -> Self;
-    fn chunk(offset: u64) -> Self;
-    fn bytes(ranges: impl RangeBounds<u64>) -> Self;
-    fn chunks(ranges: impl RangeBounds<u64>) -> Self;
-    fn offset(offset: u64) -> Self;
-}
-
-impl ChunkRangesExt for ChunkRanges {
-    fn last_chunk() -> Self {
-        ChunkRanges::from(ChunkNum(u64::MAX)..)
-    }
-
-    /// Create a chunk range that contains a single chunk.
-    fn chunk(offset: u64) -> Self {
-        ChunkRanges::from(ChunkNum(offset)..ChunkNum(offset + 1))
-    }
-
-    /// Create a range of chunks that contains the given byte ranges.
-    /// The byte ranges are rounded up to the nearest chunk size.
-    fn bytes(ranges: impl RangeBounds<u64>) -> Self {
-        round_up_to_chunks(&bounds_from_range(ranges, |v| v))
-    }
-
-    /// Create a range of chunks from u64 chunk bounds.
-    ///
-    /// This is equivalent but more convenient than using the ChunkNum newtype.
-    fn chunks(ranges: impl RangeBounds<u64>) -> Self {
-        bounds_from_range(ranges, ChunkNum)
-    }
-
-    /// Create a chunk range that contains a single byte offset.
-    fn offset(offset: u64) -> Self {
-        Self::bytes(offset..offset + 1)
-    }
-}
-
-// todo: move to range_collections
-pub(crate) fn bounds_from_range<R, T, F>(range: R, f: F) -> RangeSet2<T>
-where
-    R: RangeBounds<u64>,
-    T: RangeSetEntry,
-    F: Fn(u64) -> T,
-{
-    let from = match range.start_bound() {
-        Bound::Included(start) => Some(*start),
-        Bound::Excluded(start) => {
-            let Some(start) = start.checked_add(1) else {
-                return RangeSet2::empty();
-            };
-            Some(start)
-        }
-        Bound::Unbounded => None,
-    };
-    let to = match range.end_bound() {
-        Bound::Included(end) => end.checked_add(1),
-        Bound::Excluded(end) => Some(*end),
-        Bound::Unbounded => None,
-    };
-    match (from, to) {
-        (Some(from), Some(to)) => RangeSet2::from(f(from)..f(to)),
-        (Some(from), None) => RangeSet2::from(f(from)..),
-        (None, Some(to)) => RangeSet2::from(..f(to)),
-        (None, None) => RangeSet2::all(),
-    }
-}
-
-pub mod outboard_with_progress {
+pub(crate) mod outboard_with_progress {
     use std::io::{self, BufReader, Read};
 
     use bao_tree::{
@@ -433,7 +362,7 @@ pub mod outboard_with_progress {
     }
 }
 
-pub mod sink {
+pub(crate) mod sink {
     use std::{future::Future, io};
 
     use irpc::RpcMessage;

--- a/src/util.rs
+++ b/src/util.rs
@@ -4,7 +4,9 @@ use bao_tree::{io::round_up_to_chunks, ChunkNum, ChunkRanges};
 use range_collections::{range_set::RangeSetEntry, RangeSet2};
 
 pub mod channel;
+pub(crate) mod connection_pool;
 pub(crate) mod temp_tag;
+
 pub mod serde {
     // Module that handles io::Error serialization/deserialization
     pub mod io_error_serde {

--- a/src/util/connection_pool.rs
+++ b/src/util/connection_pool.rs
@@ -4,10 +4,10 @@
 //! ALPN and [`Options`]. Then the pool will manage connections for you.
 //!
 //! Access to connections is via the [`ConnectionPool::connect`] method, which
-//! gives you access to a connection if possible.
+//! gives you access to a connection via a [`ConnectionRef`] if possible.
 //!
-//! It is important that you use the connection only in the future passed to
-//! connect, and don't clone it out of the future.
+//! It is important that you keep the [`ConnectionRef`] alive while you are using
+//! the connection.
 use std::{
     collections::{HashMap, VecDeque},
     ops::Deref,
@@ -18,10 +18,7 @@ use std::{
     time::Duration,
 };
 
-use iroh::{
-    endpoint::ConnectError,
-    Endpoint, NodeId,
-};
+use iroh::{endpoint::ConnectError, Endpoint, NodeId};
 use n0_future::{
     future::{self},
     FuturesUnordered, MaybeFuture, Stream, StreamExt,

--- a/src/util/connection_pool.rs
+++ b/src/util/connection_pool.rs
@@ -19,7 +19,7 @@ use std::{
 };
 
 use iroh::{
-    endpoint::{ConnectError, Connection},
+    endpoint::ConnectError,
     Endpoint, NodeId,
 };
 use n0_future::{
@@ -110,8 +110,6 @@ pub enum ConnectionPoolError {
     /// The connection pool has been shut down
     Shutdown,
 }
-
-pub type PoolConnectResult = std::result::Result<Connection, PoolConnectError>;
 
 enum ActorMessage {
     RequestRef(RequestRef),

--- a/src/util/connection_pool.rs
+++ b/src/util/connection_pool.rs
@@ -3,7 +3,7 @@
 //! Entry point is [`ConnectionPool`]. You create a connection pool for a specific
 //! ALPN and [`Options`]. Then the pool will manage connections for you.
 //!
-//! Access to connections is via the [`ConnectionPool::connect`] method, which
+//! Access to connections is via the [`ConnectionPool::get_or_connect`] method, which
 //! gives you access to a connection via a [`ConnectionRef`] if possible.
 //!
 //! It is important that you keep the [`ConnectionRef`] alive while you are using
@@ -360,7 +360,7 @@ impl ConnectionPool {
     ///
     /// This is guaranteed to return after approximately [Options::connect_timeout]
     /// with either an error or a connection.
-    pub async fn connect(
+    pub async fn get_or_connect(
         &self,
         id: NodeId,
     ) -> std::result::Result<ConnectionRef, PoolConnectError> {

--- a/src/util/connection_pool.rs
+++ b/src/util/connection_pool.rs
@@ -1,0 +1,465 @@
+//! A simple iroh connection pool
+//!
+//! Entry point is [`ConnectionPool`]. You create a connection pool for a specific
+//! ALPN and [`Options`]. Then the pool will manage connections for you.
+//!
+//! Access to connections is via the [`ConnectionPool::connect`] method, which
+//! gives you access to a connection if possible.
+//!
+//! It is important that you use the connection only in the future passed to
+//! connect, and don't clone it out of the future.
+use std::{
+    collections::{HashMap, VecDeque},
+    ops::Deref,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+    time::Duration,
+};
+
+use iroh::{
+    endpoint::{ConnectError, Connection},
+    Endpoint, NodeId,
+};
+use n0_future::{
+    future::{self},
+    FuturesUnordered, MaybeFuture, Stream, StreamExt,
+};
+use snafu::Snafu;
+use tokio::sync::{
+    mpsc::{self, error::SendError as TokioSendError},
+    oneshot, Notify,
+};
+use tokio_util::time::FutureExt as TimeFutureExt;
+use tracing::{debug, error, trace};
+
+/// Configuration options for the connection pool
+#[derive(Debug, Clone, Copy)]
+pub struct Options {
+    pub idle_timeout: Duration,
+    pub connect_timeout: Duration,
+    pub max_connections: usize,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            idle_timeout: Duration::from_secs(5),
+            connect_timeout: Duration::from_secs(1),
+            max_connections: 1024,
+        }
+    }
+}
+
+/// A reference to a connection that is owned by a connection pool.
+#[derive(Debug)]
+pub struct ConnectionRef {
+    connection: iroh::endpoint::Connection,
+    _permit: OneConnection,
+}
+
+impl Deref for ConnectionRef {
+    type Target = iroh::endpoint::Connection;
+
+    fn deref(&self) -> &Self::Target {
+        &self.connection
+    }
+}
+
+impl ConnectionRef {
+    fn new(connection: iroh::endpoint::Connection, counter: OneConnection) -> Self {
+        Self {
+            connection,
+            _permit: counter,
+        }
+    }
+}
+
+/// Error when a connection can not be acquired
+///
+/// This includes the normal iroh connection errors as well as pool specific
+/// errors such as timeouts and connection limits.
+#[derive(Debug, Clone, Snafu)]
+#[snafu(module)]
+pub enum PoolConnectError {
+    /// Connection pool is shut down
+    Shutdown,
+    /// Timeout during connect
+    Timeout,
+    /// Too many connections
+    TooManyConnections,
+    /// Error during connect
+    ConnectError { source: Arc<ConnectError> },
+}
+
+impl From<ConnectError> for PoolConnectError {
+    fn from(e: ConnectError) -> Self {
+        PoolConnectError::ConnectError {
+            source: Arc::new(e),
+        }
+    }
+}
+
+/// Error when calling a fn on the [`ConnectionPool`].
+///
+/// The only thing that can go wrong is that the connection pool is shut down.
+#[derive(Debug, Snafu)]
+#[snafu(module)]
+pub enum ConnectionPoolError {
+    /// The connection pool has been shut down
+    Shutdown,
+}
+
+pub type PoolConnectResult = std::result::Result<Connection, PoolConnectError>;
+
+enum ActorMessage {
+    RequestRef(RequestRef),
+    ConnectionIdle { id: NodeId },
+    ConnectionShutdown { id: NodeId },
+}
+
+struct RequestRef {
+    id: NodeId,
+    tx: oneshot::Sender<Result<ConnectionRef, PoolConnectError>>,
+}
+
+struct Context {
+    options: Options,
+    endpoint: Endpoint,
+    owner: ConnectionPool,
+    alpn: Vec<u8>,
+}
+
+impl Context {
+    async fn run_connection_actor(
+        self: Arc<Self>,
+        node_id: NodeId,
+        mut rx: mpsc::Receiver<RequestRef>,
+    ) {
+        let context = self;
+
+        // Connect to the node
+        let state = context
+            .endpoint
+            .connect(node_id, &context.alpn)
+            .timeout(context.options.connect_timeout)
+            .await
+            .map_err(|_| PoolConnectError::Timeout)
+            .and_then(|r| r.map_err(PoolConnectError::from));
+        if let Err(e) = &state {
+            debug!(%node_id, "Failed to connect {e:?}, requesting shutdown");
+            if context.owner.close(node_id).await.is_err() {
+                return;
+            }
+        }
+        let counter = ConnectionCounter::new();
+        let idle_timer = MaybeFuture::default();
+        let idle_stream = counter.clone().idle_stream();
+
+        tokio::pin!(idle_timer, idle_stream);
+
+        loop {
+            tokio::select! {
+                biased;
+
+                // Handle new work
+                handler = rx.recv() => {
+                    match handler {
+                        Some(RequestRef { id, tx }) => {
+                            assert!(id == node_id, "Not for me!");
+                            match &state {
+                                Ok(state) => {
+                                    let res = ConnectionRef::new(state.clone(), counter.get_one());
+
+                                    // clear the idle timer
+                                    idle_timer.as_mut().set_none();
+                                    tx.send(Ok(res)).ok();
+                                }
+                                Err(cause) => {
+                                    tx.send(Err(cause.clone())).ok();
+                                }
+                            }
+                        }
+                        None => {
+                            // Channel closed - finish remaining tasks and exit
+                            break;
+                        }
+                    }
+                }
+
+                _ = idle_stream.next() => {
+                    if !counter.is_idle() {
+                        continue;
+                    };
+                    // notify the pool that we are idle.
+                    trace!(%node_id, "Idle");
+                    if context.owner.idle(node_id).await.is_err() {
+                        // If we can't notify the pool, we are shutting down
+                        break;
+                    }
+                    // set the idle timer
+                    idle_timer.as_mut().set_future(tokio::time::sleep(context.options.idle_timeout));
+                }
+
+                // Idle timeout - request shutdown
+                _ = &mut idle_timer => {
+                    trace!(%node_id, "Idle timer expired, requesting shutdown");
+                    context.owner.close(node_id).await.ok();
+                    // Don't break here - wait for main actor to close our channel
+                }
+            }
+        }
+
+        if let Ok(connection) = state {
+            let reason = if counter.is_idle() { b"idle" } else { b"drop" };
+            connection.close(0u32.into(), reason);
+        }
+
+        trace!(%node_id, "Connection actor shutting down");
+    }
+}
+
+struct Actor {
+    rx: mpsc::Receiver<ActorMessage>,
+    connections: HashMap<NodeId, mpsc::Sender<RequestRef>>,
+    context: Arc<Context>,
+    // idle set (most recent last)
+    // todo: use a better data structure if this becomes a performance issue
+    idle: VecDeque<NodeId>,
+    // per connection tasks
+    tasks: FuturesUnordered<future::Boxed<()>>,
+}
+
+impl Actor {
+    pub fn new(
+        endpoint: Endpoint,
+        alpn: &[u8],
+        options: Options,
+    ) -> (Self, mpsc::Sender<ActorMessage>) {
+        let (tx, rx) = mpsc::channel(100);
+        (
+            Self {
+                rx,
+                connections: HashMap::new(),
+                idle: VecDeque::new(),
+                context: Arc::new(Context {
+                    options,
+                    alpn: alpn.to_vec(),
+                    endpoint,
+                    owner: ConnectionPool { tx: tx.clone() },
+                }),
+                tasks: FuturesUnordered::new(),
+            },
+            tx,
+        )
+    }
+
+    fn add_idle(&mut self, id: NodeId) {
+        self.remove_idle(id);
+        self.idle.push_back(id);
+    }
+
+    fn remove_idle(&mut self, id: NodeId) {
+        self.idle.retain(|&x| x != id);
+    }
+
+    fn pop_oldest_idle(&mut self) -> Option<NodeId> {
+        self.idle.pop_front()
+    }
+
+    fn remove_connection(&mut self, id: NodeId) {
+        self.connections.remove(&id);
+        self.remove_idle(id);
+    }
+
+    async fn handle_msg(&mut self, msg: ActorMessage) {
+        match msg {
+            ActorMessage::RequestRef(mut msg) => {
+                let id = msg.id;
+                self.remove_idle(id);
+                // Try to send to existing connection actor
+                if let Some(conn_tx) = self.connections.get(&id) {
+                    if let Err(TokioSendError(e)) = conn_tx.send(msg).await {
+                        msg = e;
+                    } else {
+                        return;
+                    }
+                    // Connection actor died, remove it
+                    self.remove_connection(id);
+                }
+
+                // No connection actor or it died - check limits
+                if self.connections.len() >= self.context.options.max_connections {
+                    if let Some(idle) = self.pop_oldest_idle() {
+                        // remove the oldest idle connection to make room for one more
+                        trace!("removing oldest idle connection {}", idle);
+                        self.connections.remove(&idle);
+                    } else {
+                        msg.tx.send(Err(PoolConnectError::TooManyConnections)).ok();
+                        return;
+                    }
+                }
+                let (conn_tx, conn_rx) = mpsc::channel(100);
+                self.connections.insert(id, conn_tx.clone());
+
+                let context = self.context.clone();
+
+                self.tasks
+                    .push(Box::pin(context.run_connection_actor(id, conn_rx)));
+
+                // Send the handler to the new actor
+                if conn_tx.send(msg).await.is_err() {
+                    error!(%id, "Failed to send handler to new connection actor");
+                    self.connections.remove(&id);
+                }
+            }
+            ActorMessage::ConnectionIdle { id } => {
+                self.add_idle(id);
+                trace!(%id, "connection idle");
+            }
+            ActorMessage::ConnectionShutdown { id } => {
+                // Remove the connection from our map - this closes the channel
+                self.remove_connection(id);
+                trace!(%id, "removed connection");
+            }
+        }
+    }
+
+    pub async fn run(mut self) {
+        loop {
+            tokio::select! {
+                biased;
+
+                msg = self.rx.recv() => {
+                    if let Some(msg) = msg {
+                        self.handle_msg(msg).await;
+                    } else {
+                        break;
+                    }
+                }
+
+                _ = self.tasks.next(), if !self.tasks.is_empty() => {}
+            }
+        }
+    }
+}
+
+/// A connection pool
+#[derive(Debug, Clone)]
+pub struct ConnectionPool {
+    tx: mpsc::Sender<ActorMessage>,
+}
+
+impl ConnectionPool {
+    pub fn new(endpoint: Endpoint, alpn: &[u8], options: Options) -> Self {
+        let (actor, tx) = Actor::new(endpoint, alpn, options);
+
+        // Spawn the main actor
+        tokio::spawn(actor.run());
+
+        Self { tx }
+    }
+
+    /// Returns either a fresh connection or a reference to an existing one.
+    ///
+    /// This is guaranteed to return after approximately [Options::connect_timeout]
+    /// with either an error or a connection.
+    pub async fn connect(
+        &self,
+        id: NodeId,
+    ) -> std::result::Result<ConnectionRef, PoolConnectError> {
+        let (tx, rx) = oneshot::channel();
+        self.tx
+            .send(ActorMessage::RequestRef(RequestRef { id, tx }))
+            .await
+            .map_err(|_| PoolConnectError::Shutdown)?;
+        rx.await.map_err(|_| PoolConnectError::Shutdown)?
+    }
+
+    /// Close an existing connection, if it exists
+    ///
+    /// This will finish pending tasks and close the connection. New tasks will
+    /// get a new connection if they are submitted after this call
+    pub async fn close(&self, id: NodeId) -> std::result::Result<(), ConnectionPoolError> {
+        self.tx
+            .send(ActorMessage::ConnectionShutdown { id })
+            .await
+            .map_err(|_| ConnectionPoolError::Shutdown)?;
+        Ok(())
+    }
+
+    /// Notify the connection pool that a connection is idle.
+    ///
+    /// Should only be called from connection handlers.
+    pub(crate) async fn idle(&self, id: NodeId) -> std::result::Result<(), ConnectionPoolError> {
+        self.tx
+            .send(ActorMessage::ConnectionIdle { id })
+            .await
+            .map_err(|_| ConnectionPoolError::Shutdown)?;
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct ConnectionCounterInner {
+    count: AtomicUsize,
+    notify: Notify,
+}
+
+#[derive(Debug, Clone)]
+struct ConnectionCounter {
+    inner: Arc<ConnectionCounterInner>,
+}
+
+impl ConnectionCounter {
+    fn new() -> Self {
+        Self {
+            inner: Arc::new(ConnectionCounterInner {
+                count: Default::default(),
+                notify: Notify::new(),
+            }),
+        }
+    }
+
+    /// Increase the connection count and return a guard for the new connection
+    fn get_one(&self) -> OneConnection {
+        self.inner.count.fetch_add(1, Ordering::SeqCst);
+        OneConnection {
+            inner: self.inner.clone(),
+        }
+    }
+
+    fn is_idle(&self) -> bool {
+        self.inner.count.load(Ordering::SeqCst) == 0
+    }
+
+    /// Infinite stream that yields when the connection is briefly idle.
+    ///
+    /// Note that you still have to check if the connection is still idle when
+    /// you get the notification.
+    ///
+    /// Also note that this stream is triggered on [OneConnection::drop], so it
+    /// won't trigger initially even though a [ConnectionCounter] starts up as
+    /// idle.
+    fn idle_stream(self) -> impl Stream<Item = ()> {
+        n0_future::stream::unfold(self, |c| async move {
+            c.inner.notify.notified().await;
+            Some(((), c))
+        })
+    }
+}
+
+/// Guard for one connection
+#[derive(Debug)]
+struct OneConnection {
+    inner: Arc<ConnectionCounterInner>,
+}
+
+impl Drop for OneConnection {
+    fn drop(&mut self) {
+        if self.inner.count.fetch_sub(1, Ordering::SeqCst) == 1 {
+            self.inner.notify.notify_waiters();
+        }
+    }
+}


### PR DESCRIPTION
## Description

Let the per-connection actor watch for connection close. When the connection is closed the conn actor will tell the main actor to remove the per-conn actor, and the next connection attempt will get a new per-connection actor.

## Breaking Changes

None

## Notes & open questions

Note: there is a very low probability that a request to get a ConnectionRef will return the closed connection. But that is fine. If the connection is closed, all currently live ConnectionRefs will turn unusable anyway, what's one more? In connected state the actor will be very fast in handing out ConnectionRef, so the queue should never be full. The queue is mostly for waiting during connect.

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
