### PR TITLE
feat: Make node_id in ClientConnected optional

### DIFF
--- a/src/provider.rs
+++ b/src/provider.rs
@@ -16,7 +16,7 @@ use n0_future::StreamExt;
 use quinn::{ClosedStream, ConnectionError, ReadToEndError};
 use serde::{de::DeserializeOwned, Deserialize, Serialize};
 use tokio::select;
-use tracing::{debug, debug_span, warn, Instrument};
+use tracing::{debug, debug_span, Instrument};
 
 use crate::{
     api::{
@@ -319,14 +319,10 @@ pub async fn handle_connection(
     let connection_id = connection.stable_id() as u64;
     let span = debug_span!("connection", connection_id);
     async move {
-        let Ok(node_id) = connection.remote_node_id() else {
-            warn!("failed to get node id");
-            return;
-        };
         if let Err(cause) = progress
             .client_connected(|| ClientConnected {
                 connection_id,
-                node_id,
+                node_id: connection.remote_node_id().ok(),
             })
             .await
         {

--- a/src/provider/events.rs
+++ b/src/provider/events.rs
@@ -578,7 +578,7 @@ mod proto {
     #[derive(Debug, Serialize, Deserialize)]
     pub struct ClientConnected {
         pub connection_id: u64,
-        pub node_id: NodeId,
+        pub node_id: Option<NodeId>,
     }
 
     #[derive(Debug, Serialize, Deserialize)]

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -348,10 +348,10 @@ fn event_handler(
         while let Some(event) = events_rx.recv().await {
             match event {
                 ProviderMessage::ClientConnected(msg) => {
-                    let res = if allowed_nodes.contains(&msg.inner.node_id) {
-                        Ok(())
-                    } else {
-                        Err(AbortReason::Permission)
+                    let res = match msg.node_id {
+                        Some(node_id) if allowed_nodes.contains(&node_id) => Ok(()),
+                        Some(_) => Err(AbortReason::Permission),
+                        None => Err(AbortReason::Permission),
                     };
                     msg.tx.send(res).await.ok();
                 }


### PR DESCRIPTION
## Description

For some reason we can't get the node_id for 0rtt connections. Blobs does not use 0rtt, but it might in the future. So we don't have the node_id in all cases when we need to create a ClientConnected event.

See https://github.com/n0-computer/iroh/issues/3123

## Breaking Changes

No additional breaking changes compared to the last published version, since the ClientConnected event is new.

## Notes & open questions

Question: should we add some more stuff to the ClientConnected event since we might not have the node id? Socket addrs or something?

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
