### PR TITLE
feat: impl From for api::Store

### DIFF
--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -1446,6 +1446,12 @@ pub struct FsStore {
     db: tokio::sync::mpsc::Sender<InternalCommand>,
 }
 
+impl From<FsStore> for Store {
+    fn from(value: FsStore) -> Self {
+        Store::from_sender(value.sender)
+    }
+}
+
 impl Deref for FsStore {
     type Target = Store;
 

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -74,6 +74,12 @@ pub struct MemStore {
     client: ApiClient,
 }
 
+impl From<MemStore> for crate::api::Store {
+    fn from(value: MemStore) -> Self {
+        crate::api::Store::from_sender(value.client)
+    }
+}
+
 impl AsRef<crate::api::Store> for MemStore {
     fn as_ref(&self) -> &crate::api::Store {
         crate::api::Store::ref_from_sender(&self.client)

--- a/src/store/readonly_mem.rs
+++ b/src/store/readonly_mem.rs
@@ -59,6 +59,18 @@ impl Deref for ReadonlyMemStore {
     }
 }
 
+impl From<ReadonlyMemStore> for crate::api::Store {
+    fn from(value: ReadonlyMemStore) -> Self {
+        crate::api::Store::from_sender(value.client)
+    }
+}
+
+impl AsRef<crate::api::Store> for ReadonlyMemStore {
+    fn as_ref(&self) -> &crate::api::Store {
+        crate::api::Store::ref_from_sender(&self.client)
+    }
+}
+
 struct Actor {
     commands: tokio::sync::mpsc::Receiver<proto::Command>,
     tasks: JoinSet<()>,


### PR DESCRIPTION
## Description

Currently, when functions want a `iroh_blobs::api::Store`, and you have a `MemStore` or `FsStore`, you have to do `fs_store.as_ref().clone()` to get from the `FsStore` to the `api::Store`. I stumbled a couple of times and had to look that up, it's not very intuitive and hard to find. So to make this easier, this adds `From` impls for `api::Store` for the various stores.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
