### PR TITLE
Remove impl Deref<Blobs> for Store

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -12,7 +12,7 @@
 //!
 //! You can also [`connect`](Store::connect) to a remote store that is listening
 //! to rpc requests.
-use std::{io, net::SocketAddr, ops::Deref};
+use std::{io, net::SocketAddr};
 
 use bao_tree::io::EncodeError;
 use iroh::Endpoint;
@@ -248,14 +248,6 @@ pub type Result<T> = std::result::Result<T, Error>;
 #[repr(transparent)]
 pub struct Store {
     client: ApiClient,
-}
-
-impl Deref for Store {
-    type Target = blobs::Blobs;
-
-    fn deref(&self) -> &Self::Target {
-        blobs::Blobs::ref_from_sender(&self.client)
-    }
 }
 
 impl Store {

--- a/src/api/downloader.rs
+++ b/src/api/downloader.rs
@@ -381,7 +381,7 @@ async fn split_request<'a>(
             };
             let first = GetRequest::blob(req.hash);
             execute_get(pool, Arc::new(first), providers, store, progress).await?;
-            let size = store.observe(req.hash).await?.size();
+            let size = store.blobs().observe(req.hash).await?.size();
             anyhow::ensure!(size % 32 == 0, "Size is not a multiple of 32");
             let n = size / 32;
             Box::new(
@@ -547,8 +547,8 @@ mod tests {
         let (r1, store1, _) = node_test_setup_fs(testdir.path().join("a")).await?;
         let (r2, store2, _) = node_test_setup_fs(testdir.path().join("b")).await?;
         let (r3, store3, _) = node_test_setup_fs(testdir.path().join("c")).await?;
-        let tt1 = store1.add_slice("hello world").await?;
-        let tt2 = store2.add_slice("hello world 2").await?;
+        let tt1 = store1.blobs().add_slice("hello world").await?;
+        let tt2 = store2.blobs().add_slice("hello world 2").await?;
         let node1_addr = r1.endpoint().node_addr().initialized().await;
         let node1_id = node1_addr.node_id;
         let node2_addr = r2.endpoint().node_addr().initialized().await;
@@ -567,8 +567,8 @@ mod tests {
         while let Some(item) = progress.next().await {
             println!("Got item: {item:?}");
         }
-        assert_eq!(store3.get_bytes(tt1.hash).await?.deref(), b"hello world");
-        assert_eq!(store3.get_bytes(tt2.hash).await?.deref(), b"hello world 2");
+        assert_eq!(store3.blobs().get_bytes(tt1.hash).await?.deref(), b"hello world");
+        assert_eq!(store3.blobs().get_bytes(tt2.hash).await?.deref(), b"hello world 2");
         Ok(())
     }
 
@@ -579,10 +579,11 @@ mod tests {
         let (r1, store1, _) = node_test_setup_fs(testdir.path().join("a")).await?;
         let (r2, store2, _) = node_test_setup_fs(testdir.path().join("b")).await?;
         let (r3, store3, _) = node_test_setup_fs(testdir.path().join("c")).await?;
-        let tt1 = store1.add_slice(vec![1; 10000000]).await?;
-        let tt2 = store2.add_slice(vec![2; 10000000]).await?;
+        let tt1 = store1.blobs().add_slice(vec![1; 10000000]).await?;
+        let tt2 = store2.blobs().add_slice(vec![2; 10000000]).await?;
         let hs = [tt1.hash, tt2.hash].into_iter().collect::<HashSeq>();
         let root = store1
+            .blobs()
             .add_bytes_with_opts(AddBytesOptions {
                 data: hs.clone().into(),
                 format: crate::BlobFormat::HashSeq,
@@ -648,10 +649,11 @@ mod tests {
         let (r1, store1, _) = node_test_setup_fs(testdir.path().join("a")).await?;
         let (r2, store2, _) = node_test_setup_fs(testdir.path().join("b")).await?;
         let (r3, store3, _) = node_test_setup_fs(testdir.path().join("c")).await?;
-        let tt1 = store1.add_slice(vec![1; 10000000]).await?;
-        let tt2 = store2.add_slice(vec![2; 10000000]).await?;
+        let tt1 = store1.blobs().add_slice(vec![1; 10000000]).await?;
+        let tt2 = store2.blobs().add_slice(vec![2; 10000000]).await?;
         let hs = [tt1.hash, tt2.hash].into_iter().collect::<HashSeq>();
         let root = store1
+            .blobs()
             .add_bytes_with_opts(AddBytesOptions {
                 data: hs.clone().into(),
                 format: crate::BlobFormat::HashSeq,

--- a/src/format/collection.rs
+++ b/src/format/collection.rs
@@ -71,7 +71,7 @@ pub trait SimpleStore {
 
 impl SimpleStore for crate::api::Store {
     async fn load(&self, hash: Hash) -> anyhow::Result<Bytes> {
-        Ok(self.get_bytes(hash).await?)
+        Ok(self.blobs().get_bytes(hash).await?)
     }
 }
 
@@ -190,11 +190,12 @@ impl Collection {
     pub async fn store(self, db: &Store) -> anyhow::Result<TempTag> {
         let (links, meta) = self.into_parts();
         let meta_bytes = postcard::to_stdvec(&meta)?;
-        let meta_tag = db.add_bytes(meta_bytes).temp_tag().await?;
+        let meta_tag = db.blobs().add_bytes(meta_bytes).temp_tag().await?;
         let links_bytes = std::iter::once(*meta_tag.hash())
             .chain(links)
             .collect::<HashSeq>();
         let links_tag = db
+            .blobs()
             .add_bytes_with_opts(AddBytesOptions {
                 data: links_bytes.into(),
                 format: BlobFormat::HashSeq,

--- a/src/test.rs
+++ b/src/test.rs
@@ -25,7 +25,7 @@ pub async fn create_random_blobs<R: rand::Rng>(
             let mut rand = rand::rngs::StdRng::seed_from_u64(seed);
             let mut data = vec![0u8; size];
             rand.fill_bytes(&mut data);
-            store.add_bytes(data).into_future()
+            store.blobs().add_bytes(data).into_future()
         })
         .collect::<Vec<_>>()
         .await;
@@ -49,7 +49,7 @@ pub async fn add_hash_sequences<R: rand::Rng>(
                     tags[j].hash
                 })
                 .collect::<HashSeq>();
-            store
+            store.blobs()
                 .add_bytes_with_opts(AddBytesOptions {
                     data: hs.into(),
                     format: BlobFormat::HashSeq,


### PR DESCRIPTION
Part of https://github.com/n0-computer/iroh-blobs/issues/172

## Description

As per rust API guidelines [0], only smart pointers should implement `Deref`.
So, we remove the `impl Deref<Blobs> for Store` in this patch.

[0]: https://rust-lang.github.io/api-guidelines/predictability.html?highlight=Deref#only-smart-pointers-implement-deref-and-derefmut-c-deref


## Breaking Changes

The `impl Deref<Blobs> for Store` was removed. For all calls to `Store` functions that were referred to the underlying `Blobs` instance, use `Store::blobs()` to get a `&Blobs`.


## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [x] All breaking changes documented.
