### PR TITLE
feat: upgrade database to redb v3 compatible format

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -204,7 +204,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-11-30
+        toolchain: nightly-2025-09-28
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.9
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/checkout@v5
     - uses: dtolnay/rust-toolchain@master
       with:
-        toolchain: nightly-2024-11-30
+        toolchain: nightly-2025-09-28
     - name: Install sccache
       uses: mozilla-actions/sccache-action@v0.0.9
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3108,9 +3108,9 @@ dependencies = [
 
 [[package]]
 name = "redb"
-version = "2.4.0"
+version = "2.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea0a72cd7140de9fc3e318823b883abf819c20d478ec89ce880466dc2ef263c6"
+checksum = "8eca1e9d98d5a7e9002d0013e18d5a9b000aee942eb134883a82f06ebffb6c01"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ genawaiter = { version = "0.99.1", features = ["futures03"] }
 iroh-base = "0.92"
 irpc = { version = "0.8.0", features = ["rpc", "quinn_endpoint_setup", "spans", "stream", "derive"], default-features = false }
 iroh-metrics = { version = "0.35" }
-redb = { version = "=2.4", optional = true }
+redb = { version = "2.6.3", optional = true }
 reflink-copy = { version = "0.1.24", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
## Description

The recently released redb v3 has incompatible changes to the database format. The recommended upgrade procedure is to upgrade the database with `Database::upgrade` on redb v2.6+. The upgrade has to be done on redb v2, not v3. See https://github.com/cberner/redb/blob/master/CHANGELOG.md#removes-support-for-file-format-v2.

This updates redb to 2.6 and performs the upgrade when opening the database. Calling upgrade on an already upgraded database is a no-op.

With this merged in the next release, we can then update redb to v3 in the version after.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
