### PR TITLE
fix!: expose GC types without fs feature

### DIFF
--- a/examples/expiring-tags.rs
+++ b/examples/expiring-tags.rs
@@ -17,7 +17,10 @@ use futures_lite::StreamExt;
 use iroh_blobs::{
     api::{blobs::AddBytesOptions, Store, Tag},
     hashseq::HashSeq,
-    store::fs::options::{BatchOptions, GcConfig, InlineOptions, Options, PathOptions},
+    store::{
+        fs::options::{BatchOptions, InlineOptions, Options, PathOptions},
+        GcConfig,
+    },
     BlobFormat, Hash,
 };
 use tokio::signal::ctrl_c;

--- a/src/store/fs/options.rs
+++ b/src/store/fs/options.rs
@@ -5,8 +5,7 @@ use std::{
 };
 
 use super::{meta::raw_outboard_size, temp_name};
-pub use crate::store::gc::{GcConfig, ProtectCb, ProtectOutcome};
-use crate::Hash;
+use crate::{store::gc::GcConfig, Hash};
 
 /// Options for directories used by the file store.
 #[derive(Debug, Clone)]

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -15,3 +15,5 @@ pub(crate) mod util;
 
 /// Block size used by iroh, 2^4*1024 = 16KiB
 pub const IROH_BLOCK_SIZE: BlockSize = BlockSize::from_chunk_log(4);
+
+pub use gc::{GcConfig, ProtectCb, ProtectOutcome};


### PR DESCRIPTION
## Description

#177 made GC work with the MemStore as well. However the types needed for configuring that are still behind the `fs-store` feature. This PR exposes these types independent of feature flags.

## Breaking Changes

Moved:
`iroh_blobs::store::fs::options::{GcConfig, ProtectOutcome, ProtectCb}` are now `iroh_blobs::store::{GcConfig, ProtectOutcome, ProtectCb}`

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
