### PR TITLE
chore: release prep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1641,8 +1641,7 @@ dependencies = [
 [[package]]
 name = "iroh"
 version = "0.90.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9436f319c2d24bca1b28a2fab4477c8d2ac795ab2d3aeda142d207b38ec068f4"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#9c023bf4d7d1c3c10a9cc3b10df7e1a22c6ab7a4"
 dependencies = [
  "aead",
  "backon",
@@ -1702,8 +1701,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "0.90.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e0090050c4055b21e61cbcb856f043a2b24ad22c65d76bab91f121b4c7bece3"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#9c023bf4d7d1c3c10a9cc3b10df7e1a22c6ab7a4"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -1866,8 +1864,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "0.90.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3f3cdbdaebc92835452e4e1d0d4b36118206b0950089b7bc3654f13e843475b"
+source = "git+https://github.com/n0-computer/iroh.git?branch=main#9c023bf4d7d1c3c10a9cc3b10df7e1a22c6ab7a4"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1926,8 +1923,7 @@ dependencies = [
 [[package]]
 name = "irpc"
 version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b355fe12226ee885e1c1056a867c2cf37be2b22032a16f5ab7091069e98a966f"
+source = "git+https://github.com/n0-computer/irpc.git?branch=main#5cc624832cfed2653a20442851c203935039d6bc"
 dependencies = [
  "anyhow",
  "futures-buffered",
@@ -1949,8 +1945,7 @@ dependencies = [
 [[package]]
 name = "irpc-derive"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efeabe1ee5615ea0416340b1a6d71a16f971495859c87fad48633b6497ee7a77"
+source = "git+https://github.com/n0-computer/irpc.git?branch=main#5cc624832cfed2653a20442851c203935039d6bc"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,8 +66,8 @@ hide-proto-docs = []
 metrics = []
 default = ["hide-proto-docs"]
 
-# [patch.crates-io]
-# iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "ramfox/ticket-error" }
-# iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "ramfox/ticket-error" }
-# irpc = { git = "https://github.com/n0-computer/irpc.git", branch = "iroh-quinn-latest" }
-# irpc-derive = { git = "https://github.com/n0-computer/irpc.git", branch = "iroh-quinn-latest" }
+[patch.crates-io]
+iroh = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+iroh-base = { git = "https://github.com/n0-computer/iroh.git", branch = "main" }
+irpc = { git = "https://github.com/n0-computer/irpc.git", branch = "main" }
+irpc-derive = { git = "https://github.com/n0-computer/irpc.git", branch = "main" }

--- a/deny.toml
+++ b/deny.toml
@@ -41,4 +41,7 @@ hash = 3171872035
 path = "LICENSE"
 
 [sources]
-allow-git = []
+allow-git = [
+    "https://github.com/n0-computer/irpc.git",
+    "https://github.com/n0-computer/iroh.git",
+]


### PR DESCRIPTION
This PR updates the following dependencies to their latest versions:

- `iroh` from `https://github.com/n0-computer/iroh.git`
- `irpc` from `https://github.com/n0-computer/irpc.git`
- `iroh-base` from `https://github.com/n0-computer/iroh.git`