### PR TITLE
feat: Add Downloader::with_pool_options() constructor

### DIFF
--- a/src/api/downloader.rs
+++ b/src/api/downloader.rs
@@ -64,10 +64,6 @@ pub enum DownloadProgressItem {
 }
 
 impl DownloaderActor {
-    fn new(store: Store, endpoint: Endpoint) -> Self {
-        Self::new_with_opts(store, endpoint, Default::default())
-    }
-
     fn new_with_opts(
         store: Store,
         endpoint: Endpoint,

--- a/src/api/downloader.rs
+++ b/src/api/downloader.rs
@@ -65,15 +65,10 @@ pub enum DownloadProgressItem {
 
 impl DownloaderActor {
     fn new(store: Store, endpoint: Endpoint) -> Self {
-        Self {
-            store,
-            pool: ConnectionPool::new(endpoint, crate::ALPN, Default::default()),
-            tasks: JoinSet::new(),
-            running: HashSet::new(),
-        }
+        Self::new_with_opts(store, endpoint, Default::default())
     }
 
-    fn with_pool_options(
+    fn new_with_opts(
         store: Store,
         endpoint: Endpoint,
         pool_options: crate::util::connection_pool::Options,
@@ -354,20 +349,16 @@ impl IntoFuture for DownloadProgress {
 
 impl Downloader {
     pub fn new(store: &Store, endpoint: &Endpoint) -> Self {
-        let (tx, rx) = tokio::sync::mpsc::channel::<SwarmMsg>(32);
-        let actor = DownloaderActor::new(store.clone(), endpoint.clone());
-        n0_future::task::spawn(actor.run(rx));
-        Self { client: tx.into() }
+        Self::new_with_opts(store, endpoint, Default::default())
     }
 
-    pub fn with_pool_options(
+    pub fn new_with_opts(
         store: &Store,
         endpoint: &Endpoint,
         pool_options: crate::util::connection_pool::Options,
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel::<SwarmMsg>(32);
-        let actor =
-            DownloaderActor::with_pool_options(store.clone(), endpoint.clone(), pool_options);
+        let actor = DownloaderActor::new_with_opts(store.clone(), endpoint.clone(), pool_options);
         n0_future::task::spawn(actor.run(rx));
         Self { client: tx.into() }
     }

--- a/src/api/downloader.rs
+++ b/src/api/downloader.rs
@@ -73,6 +73,19 @@ impl DownloaderActor {
         }
     }
 
+    fn with_pool_options(
+        store: Store,
+        endpoint: Endpoint,
+        pool_options: crate::util::connection_pool::Options,
+    ) -> Self {
+        Self {
+            store,
+            pool: ConnectionPool::new(endpoint, crate::ALPN, pool_options),
+            tasks: JoinSet::new(),
+            running: HashSet::new(),
+        }
+    }
+
     async fn run(mut self, mut rx: tokio::sync::mpsc::Receiver<SwarmMsg>) {
         while let Some(msg) = rx.recv().await {
             match msg {
@@ -343,6 +356,18 @@ impl Downloader {
     pub fn new(store: &Store, endpoint: &Endpoint) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel::<SwarmMsg>(32);
         let actor = DownloaderActor::new(store.clone(), endpoint.clone());
+        n0_future::task::spawn(actor.run(rx));
+        Self { client: tx.into() }
+    }
+
+    pub fn with_pool_options(
+        store: &Store,
+        endpoint: &Endpoint,
+        pool_options: crate::util::connection_pool::Options,
+    ) -> Self {
+        let (tx, rx) = tokio::sync::mpsc::channel::<SwarmMsg>(32);
+        let actor =
+            DownloaderActor::with_pool_options(store.clone(), endpoint.clone(), pool_options);
         n0_future::task::spawn(actor.run(rx));
         Self { client: tx.into() }
     }


### PR DESCRIPTION
Adds a `Downloader::with_pool_options()` constructor that allows configuring the internal `ConnectionPool` options.

Currently `Downloader::new()` hardcodes `Default::default()` for pool options, which means the `idle_timeout` is always 5 seconds. The `ConnectionPool` and `Options` types are already public, but there's no way to pass them through to the `Downloader`.


We're from the [Psyche/Nousnet](https://github.com/PsycheFoundation/nousnet) team
In our use case, peers exchange gradient via iroh-blobs. With the 5s idle timeout, every connection gets dropped between transfers and a new one is created for the next round.

On a devnet run with 6 peers, over 8 hours we see:

```
MaxPathIdReached warnings: 3,098
NAT traversal warnings:    3,344
Connection open/close cycles per hour: ~1,300
Handshake aborts: 31
```

```
2025-03-09T10:15:02 WARN iroh: MaxPathIdReached for connection ...
2025-03-09T10:15:02 WARN iroh: NAT traversal to ... via ... failed
2025-03-09T10:15:03 new connection to peer ...
2025-03-09T10:15:25 connection closed (idle timeout)
2025-03-09T10:15:25 new connection to peer ...  <- same peer, 22s later
```

The `MaxPathIdReached` happens because QUIC path IDs are monotonically increasing and never reused, constant connection churn burns through them.

Being able to set a longer idle timeout (e.g. 60s) would let the pool reuse connections across transfers, eliminating the churn entirely.


Here is how we plan to use it on NousNet
https://github.com/PsycheFoundation/nousnet/pull/600/changes

Feedback is really appreciated