### PR TITLE
fs-store observe: treat transitional states as empty bitfields

### DIFF
--- a/src/store/fs/bao_file.rs
+++ b/src/store/fs/bao_file.rs
@@ -396,19 +396,16 @@ impl PartialMemStorage {
 impl BaoFileStorage {
     pub fn bitfield(&self) -> Bitfield {
         match self {
-            BaoFileStorage::Initial => {
-                panic!("initial storage should not be used")
-            }
-            BaoFileStorage::Loading => {
-                panic!("loading storage should not be used")
-            }
+            // Observers can briefly see transitional states while an entry is loading, being
+            // replaced, or after an operation failed. Treating those states as empty keeps observe
+            // streams recoverable until the next update arrives.
+            BaoFileStorage::Initial => Bitfield::empty(),
+            BaoFileStorage::Loading => Bitfield::empty(),
             BaoFileStorage::NonExisting => Bitfield::empty(),
             BaoFileStorage::PartialMem(x) => x.bitfield.clone(),
             BaoFileStorage::Partial(x) => x.bitfield.clone(),
             BaoFileStorage::Complete(x) => Bitfield::complete(x.data.size()),
-            BaoFileStorage::Poisoned => {
-                panic!("poisoned storage should not be used")
-            }
+            BaoFileStorage::Poisoned => Bitfield::empty(),
         }
     }
 
@@ -745,5 +742,41 @@ impl BaoFileStorageSubscriber {
             }
             e = self.receiver.changed() => Ok(e.anyerr()?),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use irpc::channel::mpsc;
+    use tokio::sync::watch;
+
+    use super::*;
+
+    #[test]
+    fn bitfield_is_empty_for_transitional_states() {
+        assert_eq!(BaoFileStorage::Initial.bitfield(), Bitfield::empty());
+        assert_eq!(BaoFileStorage::Loading.bitfield(), Bitfield::empty());
+        assert_eq!(BaoFileStorage::Poisoned.bitfield(), Bitfield::empty());
+    }
+
+    #[tokio::test]
+    async fn subscriber_forward_emits_empty_bitfield_for_transitional_state() {
+        let (_state_tx, state_rx) = watch::channel(BaoFileStorage::Loading);
+        let subscriber = BaoFileStorageSubscriber::new(state_rx);
+        let (tx, mut rx) = mpsc::channel(1);
+        let forward = tokio::spawn(async move { subscriber.forward(tx).await });
+
+        let first = rx
+            .recv()
+            .await
+            .expect("receiver should stay open")
+            .expect("subscriber should emit an initial bitfield");
+        assert!(first.is_empty());
+
+        drop(rx);
+        assert!(forward
+            .await
+            .expect("subscriber task should not panic")
+            .is_err());
     }
 }


### PR DESCRIPTION
## Description

  `BaoFileStorage::bitfield()` currently panics when an observer sees
  `Initial`, `Loading`, or `Poisoned`.

  `BaoFileStorageSubscriber::forward()` reads `borrow().bitfield()` immediately
  when an observe stream starts, so a subscriber can panic if it attaches while
  an entry is still loading, being replaced, or left in a transitional state
  after a failed operation.

  This change treats those transitional states as `Bitfield::empty()` instead.

## Why

  For observe streams, an empty bitfield preserves the "not complete yet"
  semantics without turning a transient internal state into a fatal failure.

  This also matches the surrounding fs-store behavior more closely:
  other paths already treat these states as recoverable/no-op states instead of
  requiring an unconditional abort.

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

### Tests

  - add `bitfield_is_empty_for_transitional_states`
  - add `subscriber_forward_emits_empty_bitfield_for_transitional_state`

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
