### PR TITLE
fix: improve store robustness with descriptive panics and GC safety docs

### DIFF
--- a/src/hash.rs
+++ b/src/hash.rs
@@ -299,7 +299,9 @@ mod redb_support {
         where
             Self: 'a,
         {
-            let contents: &'a [u8; 32] = data.try_into().unwrap();
+            let contents: &'a [u8; 32] = data
+                .try_into()
+                .expect("redb provided wrong-sized data for Hash (expected 32 bytes)");
             (*contents).into()
         }
 
@@ -335,8 +337,11 @@ mod redb_support {
         where
             Self: 'a,
         {
-            let t: &'a [u8; Self::POSTCARD_MAX_SIZE] = data.try_into().unwrap();
-            postcard::from_bytes(t.as_slice()).unwrap()
+            let t: &'a [u8; Self::POSTCARD_MAX_SIZE] = data
+                .try_into()
+                .expect("redb provided wrong-sized data for HashAndFormat (expected 33 bytes)");
+            postcard::from_bytes(t.as_slice())
+                .expect("redb data failed postcard deserialization for HashAndFormat")
         }
 
         fn as_bytes<'a, 'b: 'a>(value: &'a Self::SelfType<'b>) -> Self::AsBytes<'a>
@@ -345,7 +350,8 @@ mod redb_support {
             Self: 'b,
         {
             let mut res = [0u8; 33];
-            postcard::to_slice(&value, &mut res).unwrap();
+            postcard::to_slice(&value, &mut res)
+                .expect("HashAndFormat serialization failed (exceeds 33 bytes)");
             res
         }
 

--- a/src/store/fs/delete_set.rs
+++ b/src/store/fs/delete_set.rs
@@ -20,6 +20,17 @@ pub(super) enum BaoFilePart {
 ///
 /// The protect handle can be used to protect files from deletion.
 /// The delete handle can be used to create transactions in which files can be marked for deletion.
+///
+/// # Concurrency safety
+///
+/// The protect handle is safe to use concurrently with GC transactions. The
+/// shared `Mutex<DeleteSet>` ensures that:
+/// - If `protect()` is called before `commit()`, the hash is removed from the
+///   delete set and its files are preserved.
+/// - If `protect()` is called after `commit()` (files already deleted), the
+///   protect is a no-op on an empty set, and the import will recreate the files.
+/// - The meta actor processes commands sequentially, so GC and imports cannot
+///   interleave their database operations.
 pub(super) fn pair(options: Arc<PathOptions>) -> (ProtectHandle, DeleteHandle) {
     let ds = Arc::new(Mutex::new(DeleteSet::default()));
     (ProtectHandle(ds.clone()), DeleteHandle::new(ds, options))


### PR DESCRIPTION
## Summary
- Add descriptive messages to panic-prone operations in the store layer
- Document GC safety invariants to prevent data loss from concurrent operations

## Test plan
- [x] All tests pass
- [x] `cargo make format-check` passes
- [x] `cargo clippy -- -D warnings` passes