### PR TITLE
fix: correct misleading MAX_MESSAGE_SIZE doc comment

### DIFF
--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -392,7 +392,7 @@ pub use range_spec::{ChunkRangesSeq, NonEmptyRequestRangeSpecIter, RangeSpec};
 
 use crate::{api::blobs::Bitfield, util::RecvStreamExt, BlobFormat, Hash, HashAndFormat};
 
-/// Maximum message size is limited to 100MiB for now.
+/// Maximum message size is limited to 1MiB for now.
 pub const MAX_MESSAGE_SIZE: usize = 1024 * 1024;
 
 /// Error code for a permission error


### PR DESCRIPTION
## Summary
- The doc comment said "100MiB" but the value is 1MiB (1024 * 1024 = 1,048,576 bytes)
- Fix the comment to match the actual limit

## Test plan
- [x] All tests pass
- [x] `cargo make format-check` passes
- [x] `cargo clippy -- -D warnings` passes