### PR TITLE
fix(api/downloader): reap completed download tasks

### DIFF
--- a/src/api/downloader.rs
+++ b/src/api/downloader.rs
@@ -1,6 +1,6 @@
 //! API for downloads from multiple nodes.
 use std::{
-    collections::{HashMap, HashSet},
+    collections::HashMap,
     fmt::Debug,
     future::{Future, IntoFuture},
     sync::Arc,
@@ -8,9 +8,16 @@ use std::{
 
 use genawaiter::sync::Gen;
 use iroh::{Endpoint, EndpointId};
-use irpc::{channel::mpsc, rpc_requests};
+use irpc::{
+    channel::{mpsc, oneshot},
+    rpc_requests,
+};
 use n0_error::{anyerr, Result};
-use n0_future::{future, stream, task::JoinSet, BufferedStreamExt, Stream, StreamExt};
+use n0_future::{
+    future, stream,
+    task::{JoinError, JoinSet},
+    BufferedStreamExt, Stream, StreamExt,
+};
 use rand::seq::SliceRandom;
 use serde::{de::Error, Deserialize, Serialize};
 use tracing::instrument::Instrument;
@@ -35,13 +42,18 @@ pub struct Downloader {
 enum SwarmProtocol {
     #[rpc(tx = mpsc::Sender<DownloadProgressItem>)]
     Download(DownloadRequest),
+    #[rpc(tx = oneshot::Sender<()>)]
+    WaitIdle(WaitIdleRequest),
 }
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct WaitIdleRequest;
 
 struct DownloaderActor {
     store: Store,
     pool: ConnectionPool,
     tasks: JoinSet<()>,
-    running: HashSet<n0_future::task::Id>,
+    idle_waiters: Vec<irpc::channel::oneshot::Sender<()>>,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -73,28 +85,58 @@ impl DownloaderActor {
             store,
             pool: ConnectionPool::new(endpoint, crate::ALPN, pool_options),
             tasks: JoinSet::new(),
-            running: HashSet::new(),
+            idle_waiters: Vec::new(),
         }
     }
 
     async fn run(mut self, mut rx: tokio::sync::mpsc::Receiver<SwarmMsg>) {
-        while let Some(msg) = rx.recv().await {
-            match msg {
-                SwarmMsg::Download(request) => {
-                    self.spawn(handle_download(
-                        self.store.clone(),
-                        self.pool.clone(),
-                        request,
-                    ));
+        loop {
+            tokio::select! {
+                msg = rx.recv() => {
+                    let Some(msg) = msg else { break };
+                    match msg {
+                        SwarmMsg::Download(request) => {
+                            self.spawn(handle_download(
+                                self.store.clone(),
+                                self.pool.clone(),
+                                request,
+                            ));
+                        }
+                        SwarmMsg::WaitIdle(WaitIdleMsg { tx, .. }) => {
+                            if self.tasks.is_empty() {
+                                tx.send(()).await.ok();
+                            } else {
+                                self.idle_waiters.push(tx);
+                            }
+                        }
+                    }
+                }
+                Some(res) = self.tasks.join_next(), if !self.tasks.is_empty() => {
+                    Self::log_task_result(res);
+                    if self.tasks.is_empty() {
+                        for tx in self.idle_waiters.drain(..) {
+                            tx.send(()).await.ok();
+                        }
+                    }
                 }
             }
+        }
+        while let Some(res) = self.tasks.join_next().await {
+            Self::log_task_result(res);
+        }
+    }
+
+    fn log_task_result(res: std::result::Result<(), JoinError>) {
+        match res {
+            Ok(()) => {}
+            Err(e) if e.is_cancelled() => tracing::trace!("download task cancelled: {e}"),
+            Err(e) => tracing::error!("download task failed: {e}"),
         }
     }
 
     fn spawn(&mut self, fut: impl Future<Output = ()> + Send + 'static) {
         let span = tracing::Span::current();
-        let id = self.tasks.spawn(fut.instrument(span)).id();
-        self.running.insert(id);
+        self.tasks.spawn(fut.instrument(span));
     }
 }
 
@@ -377,6 +419,21 @@ impl Downloader {
         let fut = self.client.server_streaming(options, 32);
         DownloadProgress::new(Box::pin(fut))
     }
+
+    /// Wait until the downloader has no in-flight download tasks.
+    ///
+    /// This is mostly useful for tests, where you want to confirm that all
+    /// previously-issued downloads have settled (whether they completed
+    /// successfully or errored out). Note that the downloader is not
+    /// guaranteed to become idle if it is being interacted with concurrently;
+    /// in that case this might wait forever. Also note that once you get the
+    /// callback, the downloader is not guaranteed to still be idle — all this
+    /// tells you is that there was a point in time, between the call and the
+    /// response, where it was idle.
+    pub async fn wait_idle(&self) -> irpc::Result<()> {
+        self.client.rpc(WaitIdleRequest).await?;
+        Ok(())
+    }
 }
 
 /// Split a request into multiple requests that can be run in parallel.
@@ -550,6 +607,7 @@ mod tests {
         hashseq::HashSeq,
         protocol::{GetManyRequest, GetRequest},
         tests::node_test_setup_fs,
+        Hash,
     };
 
     #[tokio::test]
@@ -682,6 +740,55 @@ mod tests {
             .stream()
             .await?;
         while progress.next().await.is_some() {}
+        Ok(())
+    }
+
+    /// Invariant: `DownloaderActor` must reap each `handle_download` task
+    /// from its `JoinSet` as that task finishes, not only on shutdown.
+    /// If steady-state reaping is skipped, every completed download
+    /// retains its tokio task header for the lifetime of the actor and
+    /// the heap grows linearly with download volume — invisible at the
+    /// API surface, since downloads still report progress and finish.
+    ///
+    /// We submit many downloads with an empty provider list so each
+    /// `handle_download` finishes in microseconds with no I/O, then
+    /// assert the actor reaches an idle state via [`Downloader::wait_idle`].
+    /// If the `tasks.join_next()` arm is removed from
+    /// `DownloaderActor::run`'s `select!`, the JoinSet stays full of
+    /// completed-but-not-joined tasks, `tasks.is_empty()` never becomes
+    /// true, and the timeout below fires.
+    ///
+    /// The complementary `idle_waiters` notification path is not
+    /// exercised here: by the time this test calls `wait_idle`, the
+    /// actor has already drained the JoinSet during the per-stream
+    /// awaits, so `wait_idle`'s fast path answers directly.
+    #[tokio::test]
+    async fn downloader_drains_completed_tasks() -> TestResult<()> {
+        let testdir = tempfile::tempdir()?;
+        let (r, store, _, _) = node_test_setup_fs(testdir.path().join("a")).await?;
+        let swarm = Downloader::new(&store, r.endpoint());
+
+        let n = 1_000;
+        let bogus_hash = Hash::new(b"this hash is not stored anywhere");
+        let mut streams = Vec::with_capacity(n);
+        for _ in 0..n {
+            streams.push(
+                swarm
+                    .download(GetRequest::all(bogus_hash), Shuffled::new(vec![]))
+                    .stream()
+                    .await?,
+            );
+        }
+        for mut s in streams {
+            while s.next().await.is_some() {}
+        }
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), swarm.wait_idle())
+            .await
+            .map_err(|_| {
+                "wait_idle did not resolve within 5s — DownloaderActor JoinSet not draining"
+            })??;
+
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

`DownloaderActor::run` was a bare `while let Some(msg) = rx.recv()` loop that only spawned `handle_download` tasks and never drained its `JoinSet`. Every completed download therefore retained its tokio task header for the lifetime of the actor, leaking memory linearly with download volume on a long-running node. This is invisible at the API surface, since downloads still report progress and finish.

This PR adopts the steady-state reaper pattern already used by every other actor in this crate (`store/mem.rs`, `store/fs.rs`, `store/readonly_mem.rs`).

Changes in `src/api/downloader.rs`:

- Rewrite `DownloaderActor::run` as a `tokio::select!` racing `rx.recv()` against `Some(res) = self.tasks.join_next(), if !self.tasks.is_empty()`. Add a `log_task_result` helper that traces cancelled tasks and logs panics. After the loop breaks, a `while let Some(res) = self.tasks.join_next().await` performs a graceful drain on shutdown.
- Add a `WaitIdle(WaitIdleRequest)` variant to `SwarmProtocol` plus an `idle_waiters: Vec<oneshot::Sender<()>>` field on the actor, mirroring `api::proto::Command::WaitIdle`. The drain arm fires every parked waiter once `tasks.is_empty()`.
- Add a public `Downloader::wait_idle()` method, mirroring `api::Store::wait_idle` (`src/api.rs:294`). Useful for tests and for any caller that needs to confirm prior downloads have settled.
- Delete the `running: HashSet<n0_future::task::Id>` field. ripgrep showed three references in the entire crate (declaration, initialization, insert) and zero reads — vestigial dead state, never part of any public surface, and removing it lets `spawn` shrink to a one-liner that matches the other actors.
- Add a regression test, `api::downloader::tests::downloader_drains_completed_tasks`, that submits 1000 downloads against an empty provider list (each `handle_download` returns immediately, no I/O) and asserts `tokio::time::timeout(5s, swarm.wait_idle())` resolves. With the drain arm removed from the `select!`, the JoinSet stays full of completed-but-not-joined tasks and the timeout fires.

## Breaking Changes

None. The change is purely additive at the public API: one new `pub async fn wait_idle(&self) -> irpc::Result<()>` on `Downloader`. The deleted `running` field was a private field on a private struct, unreachable from outside the crate.

## Notes & open questions

- The complementary slow path of `wait_idle` — parking the reply sender in `idle_waiters` and notifying it from the drain arm — is not under test. By the time the regression test calls `wait_idle`, the actor has already drained the JoinSet during the per-stream awaits, so `wait_idle`'s fast path answers directly. The test deliberately targets the steady-state reaper, which is where the leak actually lived; the parking/notification logic is short and adjacent, kept as correctness-by-construction. A second test that constructs the actor manually with deliberately slow tasks could cover that path if reviewers want it.
- Backpressure / max-in-flight is intentionally out of scope. This PR is the leak fix only. A hard cap on concurrent downloads would be a useful follow-up but should be discussed and implemented separately.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
