### PR TITLE
debug: get trace log

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -117,7 +117,7 @@ jobs:
         mkdir -p output
         cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
       env:
-        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+        RUST_LOG: noq_proto=trace,iroh=debug,iroh_blobs=debug,debug
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
 
     - name: upload results
@@ -216,7 +216,7 @@ jobs:
         mkdir -p output
         cargo nextest run --workspace ${{ env.FEATURES }} --lib --bins --tests --profile ci --target ${{ matrix.target }} --run-ignored ${{ inputs.flaky && 'all' || 'default' }} --no-fail-fast --message-format ${{ inputs.flaky && 'libtest-json' || 'human' }} > output/${{ matrix.name }}_${{ matrix.features }}_${{ matrix.rust }}.json
       env:
-        RUST_LOG: ${{ runner.debug && 'TRACE' || 'DEBUG'}}
+        RUST_LOG: noq_proto=trace,iroh=debug,iroh_blobs=debug,debug
         NEXTEST_EXPERIMENTAL_LIBTEST_JSON: 1
   
     - name: upload results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1789,8 +1789,7 @@ dependencies = [
 [[package]]
 name = "iroh"
 version = "1.0.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b98e206e3d3f2642f5c08c413755fc0ac19b54ae1a656af88be03454ce3ed2e6"
+source = "git+https://github.com/n0-computer/iroh?branch=fix-double-close#74ef03842ff2b1ccc213266261d037bebff9e7e6"
 dependencies = [
  "backon",
  "blake3",
@@ -1842,8 +1841,7 @@ dependencies = [
 [[package]]
 name = "iroh-base"
 version = "1.0.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2160a45265eba3bd290ce698f584c9b088bee47e518e9ec4460d5e5888ef660e"
+source = "git+https://github.com/n0-computer/iroh?branch=fix-double-close#74ef03842ff2b1ccc213266261d037bebff9e7e6"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
@@ -1919,8 +1917,7 @@ dependencies = [
 [[package]]
 name = "iroh-dns"
 version = "1.0.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8b6d2946350d398c9d2d795bb99b04f22e8414c8a8ad9c5c3c0c5b7899af9a4"
+source = "git+https://github.com/n0-computer/iroh?branch=fix-double-close#74ef03842ff2b1ccc213266261d037bebff9e7e6"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -2003,8 +2000,7 @@ dependencies = [
 [[package]]
 name = "iroh-relay"
 version = "1.0.0-rc.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f490405e42dd2ecf16be18a3587d2665401e94a498094f12322eaa6d5ebb2b"
+source = "git+https://github.com/n0-computer/iroh?branch=fix-double-close#74ef03842ff2b1ccc213266261d037bebff9e7e6"
 dependencies = [
  "blake3",
  "bytes",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,3 +99,7 @@ required-features = ["fs-store"]
 [[example]]
 name = "random_store"
 required-features = ["fs-store"]
+
+[patch.crates-io]
+iroh = { git = "https://github.com/n0-computer/iroh", branch = "fix-double-close" }
+iroh-base = { git = "https://github.com/n0-computer/iroh", branch = "fix-double-close" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ serde_test = "1.0.177"
 tempfile = "3.17.1"
 test-strategy = "0.4.0"
 testresult = "0.4.1"
-tracing-subscriber = { version = "0.3.20", features = ["fmt"] }
+tracing-subscriber = { version = "0.3.20", features = ["fmt", "env-filter"] }
 tracing-test = "0.2.5"
 walkdir = "2.5.0"
 atomic_refcell = "0.1.13"


### PR DESCRIPTION
## Description

We got a bug where connections are closed from both sides, so that none are left and we time out.

This happens only on machines with at least 2 ip connections, so on our CI only Linux.

This branch is to get trace logs for this bug and to evaluate fixes. Current fix: https://github.com/n0-computer/iroh/pull/4245

## Breaking Changes

<!-- Optional, if there are any breaking changes document them, including how to migrate older code. -->

## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->

## Change checklist

- [ ] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant.
- [ ] All breaking changes documented.
