### PR TITLE
docs: add temp_tag pattern for protecting long-running downloads

### DIFF
--- a/src/api/blobs.rs
+++ b/src/api/blobs.rs
@@ -91,7 +91,7 @@ impl Blobs {
         Self::ref_cast(sender)
     }
 
-    /// Create a new batch scope.
+    /// Creates a new batch scope.
     ///
     /// A batch holds open a set of temporary tags that protect blobs from
     /// garbage collection for as long as the batch is alive. When the batch is
@@ -583,6 +583,7 @@ impl<'a> BatchAddProgress<'a> {
 /// // ... perform long-running write or network download here ...
 ///
 /// drop(_guard);
+/// // Any un-upgraded blobs from the batch are now eligible for garbage collection
 /// # Ok(())
 /// # }
 /// ```
@@ -630,7 +631,7 @@ impl<'a> Batch<'a> {
         }))
     }
 
-    /// Pin a hash inside this batch scope, protecting it from garbage collection.
+    /// Pins a hash inside this batch scope, protecting it from garbage collection.
     ///
     /// The returned [`TempTag`] keeps the blob alive until either the tag or
     /// the batch is dropped. This is the recommended way to protect a blob

--- a/src/api/blobs.rs
+++ b/src/api/blobs.rs
@@ -91,6 +91,19 @@ impl Blobs {
         Self::ref_cast(sender)
     }
 
+    /// Create a new batch scope.
+    ///
+    /// A batch holds open a set of temporary tags that protect blobs from
+    /// garbage collection for as long as the batch is alive. When the batch is
+    /// dropped, all its temporary tags are released and the protected blobs
+    /// become eligible for collection again.
+    ///
+    /// Use a batch whenever a long-running operation needs to protect a blob
+    /// in the middle of a write, e.g. when downloading a large blob that takes
+    /// longer than the GC interval. Without a temp tag, GC may collect the
+    /// partially written data file before the operation completes.
+    ///
+    /// See [`Batch::temp_tag`] to pin a specific hash inside the batch scope.
     pub async fn batch(&self) -> irpc::Result<Batch<'_>> {
         let msg = BatchRequest;
         trace!("{msg:?}");
@@ -543,7 +556,36 @@ impl<'a> BatchAddProgress<'a> {
     }
 }
 
-/// A batch of operations that modify the blob store.
+/// A scoped lifetime that protects blobs from garbage collection.
+///
+/// All temporary tags created through a `Batch` are kept alive until the batch
+/// is dropped, at which point they are released atomically and the protected
+/// blobs become eligible for GC again.
+///
+/// A typical use case is protecting a blob during a long-running write
+/// (or download) where GC could otherwise collect the partially-written data.
+///
+/// # Example
+///
+/// ```rust
+/// use iroh_blobs::{store::mem::MemStore, Hash};
+///
+/// # async fn example() -> n0_error::Result<()> {
+/// let store = MemStore::new();
+///
+/// // Hash is known upfront (e.g. from a download ticket).
+/// let hash = Hash::new(b"example content");
+///
+/// let batch = store.blobs().batch().await?;
+/// let _guard = batch.temp_tag(hash).await?;
+/// // GC will not collect `hash` for as long as `_guard` and `batch` are alive.
+///
+/// // ... perform long-running write or network download here ...
+///
+/// drop(_guard);
+/// # Ok(())
+/// # }
+/// ```
 pub struct Batch<'a> {
     scope: Scope,
     blobs: &'a Blobs,
@@ -588,6 +630,12 @@ impl<'a> Batch<'a> {
         }))
     }
 
+    /// Pin a hash inside this batch scope, protecting it from garbage collection.
+    ///
+    /// The returned [`TempTag`] keeps the blob alive until either the tag or
+    /// the batch is dropped. This is the recommended way to protect a blob
+    /// during a long-running write or download where GC might otherwise collect
+    /// the partially-written data.
     pub async fn temp_tag(&self, value: impl Into<HashAndFormat>) -> irpc::Result<TempTag> {
         let value = value.into();
         let msg = CreateTempTagRequest {

--- a/src/store/gc.rs
+++ b/src/store/gc.rs
@@ -131,6 +131,9 @@ fn gc_sweep<'a>(
 }
 
 /// Configuration for garbage collection.
+///
+/// To protect individual blobs during long-running writes without pausing the
+/// GC schedule, use [`crate::api::blobs::Batch::temp_tag`].
 #[derive(derive_more::Debug, Clone)]
 pub struct GcConfig {
     /// Interval in which to run garbage collection.

--- a/src/store/gc.rs
+++ b/src/store/gc.rs
@@ -132,8 +132,8 @@ fn gc_sweep<'a>(
 
 /// Configuration for garbage collection.
 ///
-/// To protect individual blobs during long-running writes without pausing the
-/// GC schedule, use [`crate::api::blobs::Batch::temp_tag`].
+/// To protect blobs during long-running writes without pausing the GC
+/// schedule, use [`crate::api::blobs::Batch::temp_tag`].
 #[derive(derive_more::Debug, Clone)]
 pub struct GcConfig {
     /// Interval in which to run garbage collection.


### PR DESCRIPTION
References #235

## Description

Batch::temp_tag offers blob protection from GC during a long-running write or download, but it was a little easy to miss for lack of documentation. This PR adds doc comments explaining the pattern:

- `Blobs::batch()`: explains what a batch scope is
- `Batch struct`: full use-case explanation and practical rust `# Example`
- `Batch::temp_tag()`: explains the protection mechanism
- `GcConfig`: adds a cross-reference pointing readers to `Batch::temp_tag`

## Notes & open questions

I followed the existing `async fn example()` doc-test convention used elsewhere in the codebase.

The explicit `drop(_guard)` at the end of the example is intentional: in my opinion it makes visible the lifetime boundary to the reader. Without it, someone could miss that is the moment protection ends. That said, if the scope closes right there, `_guard` goes obviously out of scope and GC becomes free to collect. So, the suggested explicit `drop` is only meaningful when you want to release protection **before** the surrounding scope ends.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [ ] Tests if relevant. (none, docs-only here)
- [ ] All breaking changes documented. (none)
