### PR TITLE
fix: report the empty blob as `Complete` from `status`

### DIFF
--- a/src/api/blobs.rs
+++ b/src/api/blobs.rs
@@ -506,6 +506,10 @@ impl Blobs {
 
     pub async fn status(&self, hash: impl Into<Hash>) -> irpc::Result<BlobStatus> {
         let hash = hash.into();
+        // the empty blob is always complete, regardless of backend state
+        if hash == Hash::EMPTY {
+            return Ok(BlobStatus::Complete { size: 0 });
+        }
         let msg = BlobStatusRequest { hash };
         self.client.rpc(msg).await
     }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -532,6 +532,37 @@ pub async fn node_test_setup_with_events_mem(
     Ok((router, store, sp))
 }
 
+/// The empty blob is always complete, and `status`/`has` must agree with
+/// `observe`/`export_bao` on every backend.
+async fn empty_hash_is_complete(store: &Store) -> TestResult<()> {
+    use crate::api::blobs::BlobStatus;
+    let status = store.blobs().status(Hash::EMPTY).await?;
+    assert_eq!(status, BlobStatus::Complete { size: 0 });
+    assert!(store.blobs().has(Hash::EMPTY).await?);
+    let observed = store.blobs().observe(Hash::EMPTY).await?;
+    assert!(observed.is_complete());
+    assert_eq!(observed.size(), 0);
+    let exported = store
+        .export_bao(Hash::EMPTY, ChunkRanges::all())
+        .data_to_bytes()
+        .await?;
+    assert!(exported.is_empty());
+    Ok(())
+}
+
+#[tokio::test]
+async fn empty_hash_is_complete_mem() -> TestResult<()> {
+    let store = MemStore::new();
+    empty_hash_is_complete(&store).await
+}
+
+#[tokio::test]
+async fn empty_hash_is_complete_fs() -> TestResult<()> {
+    let testdir = tempfile::tempdir()?;
+    let store = FsStore::load(testdir.path().join("db")).await?;
+    empty_hash_is_complete(&store).await
+}
+
 /// Sets up two nodes with a router and a blob store each.
 async fn two_node_test_setup_fs() -> TestResult<(
     TempDir,


### PR DESCRIPTION
## Description

`Store::blobs().status(hash)` mishandled the empty blob (`Hash::EMPTY`, the BLAKE3 hash of zero bytes). The empty blob is trivially complete and always available (there is no data to fetch), but `status` reported otherwise, and the three store backends disagreed with each other:

| query | fs | mem | readonly_mem |
|---|---|---|---|
| `status(EMPTY)` | `NotFound` | `Partial { size: None }` | `NotFound` |
| `has(EMPTY)` | `false` | `false` | `false` |
| `observe(EMPTY)` | `Complete` (size 0) | `Complete` (size 0) | n/a |
| `export_bao(EMPTY)` | ✅ 0 bytes | ✅ 0 bytes | n/a |

Both backends also disagreed with the *rest* of the blobs API, which already treats the empty blob as available everywhere else: `observe` yields `Bitfield::complete(0)`, `export_bao` succeeds with empty data, fs `get_entry_state()` returns `EntryState::Complete`, and remote get / import both special-case it as a valid, trivially-complete blob.

This surfaced downstream in iroh-docs, which represents deletions as "tombstone" entries whose content hash is `Hash::EMPTY`. It calls `status(hash)` and treats `BlobStatus::NotFound` as "content missing", so every deleted key was reported as having missing content (visible in live sync events and over its set-reconciliation wire protocol).

### Changes

- `status` now short-circuits `Hash::EMPTY` to `BlobStatus::Complete { size: 0 }` at the API layer, before dispatching the backend RPC. This mirrors the existing special-casing in `observe_with_opts`, fixes all three backends (and any future backend) with a single source of truth, and makes `has(EMPTY)` correctly return `true` (since `has` is defined as `status() == Complete`).
- Added a regression test (`empty_hash_is_complete`, run against both the mem and fs backends) asserting `status`/`has`/`observe`/`export_bao` all agree that the empty blob is complete with size 0. It is a pure public-`Store`-API repro: it drives only `Store::blobs()` / `Store::export_bao`, with no reach into backend internals, so it reproduces exactly what a downstream consumer sees.

## Breaking Changes

None. `status(Hash::EMPTY)` previously returned `NotFound` (fs/readonly-mem) or `Partial` (mem); it now returns `Complete { size: 0 }`, and `has(Hash::EMPTY)` now returns `true` instead of `false`. This is a bug fix that brings `status` into line with the rest of the API.

The change only ever moves the empty hash toward "more available" (`NotFound`/`Partial`/`false` becomes `Complete`/`true`). Because the empty blob is reconstructible from zero bytes, treating it as present can never cause a failed read or data loss; the worst case is skipping a fetch that was never needed. This holds for external consumers as well as internal ones, so no consumer can be harmed by the new behavior.

## Notes & open questions

- Fixed at the API layer rather than in each backend's actor handler, matching the `observe_with_opts` precedent. This is unreachable through `Store`, but it leaves the backends internally inconsistent for a direct `BlobStatusRequest` to the actor. Both backends are affected, not just one:
  - mem: `get(Hash::EMPTY)` returns the `empty_hash` handle, but it is a `new_partial` with an empty bitfield, so the status handler reports `Partial`, while `observe` reports complete.
  - fs: `meta::handle_get_blob_status` reads the `blobs()` table directly with no empty-hash case and returns `NotFound`, while `get_entry_state` special-cases `Hash::EMPTY` to `EntryState::Complete`. So fs disagrees with itself.

  Open question: leave the API short-circuit as the single source of truth, or also reconcile each backend's actor handler so a raw `BlobStatusRequest` agrees too? The latter is the full residual and touches both `mem.rs` and `fs/meta.rs`.

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
