### PR TITLE
Allow specifying custom ALPN for Downloader

### DIFF
--- a/src/api/downloader.rs
+++ b/src/api/downloader.rs
@@ -79,11 +79,12 @@ impl DownloaderActor {
     fn new_with_opts(
         store: Store,
         endpoint: Endpoint,
+        alpn: &[u8],
         pool_options: crate::util::connection_pool::Options,
     ) -> Self {
         Self {
             store,
-            pool: ConnectionPool::new(endpoint, crate::ALPN, pool_options),
+            pool: ConnectionPool::new(endpoint, alpn, pool_options),
             tasks: JoinSet::new(),
             idle_waiters: Vec::new(),
         }
@@ -387,16 +388,18 @@ impl IntoFuture for DownloadProgress {
 
 impl Downloader {
     pub fn new(store: &Store, endpoint: &Endpoint) -> Self {
-        Self::new_with_opts(store, endpoint, Default::default())
+        Self::new_with_opts(store, endpoint, crate::ALPN, Default::default())
     }
 
     pub fn new_with_opts(
         store: &Store,
         endpoint: &Endpoint,
+        alpn: &[u8],
         pool_options: crate::util::connection_pool::Options,
     ) -> Self {
         let (tx, rx) = tokio::sync::mpsc::channel::<SwarmMsg>(32);
-        let actor = DownloaderActor::new_with_opts(store.clone(), endpoint.clone(), pool_options);
+        let actor =
+            DownloaderActor::new_with_opts(store.clone(), endpoint.clone(), alpn, pool_options);
         n0_future::task::spawn(actor.run(rx));
         Self { client: tx.into() }
     }


### PR DESCRIPTION
## Description

Adds ALPN as a parameter to `Downloader::new_with_opts`, to allow operation with custom ALPNs

## Breaking Changes

Use of `Downloader::new_with_opts` must provide `iroh_blobs::ALPN` as the the new arg.

## Notes & open questions

This is necessary for use with p2panda, which internally hashes any registered ALPNs with a private "network ID", making it impossible to interoperate protocols across the p2panda boundary using default ALPNs.

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [ ] All breaking changes documented.
