### PR TITLE
fs store: preserve recoverable states and terminate broken observes

### DIFF
--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -99,7 +99,7 @@ use n0_future::{future::yield_now, io};
 use nested_enum_utils::enum_conversions;
 use range_collections::range_set::RangeSetRange;
 use tokio::task::{JoinError, JoinSet};
-use tracing::{error, instrument, trace};
+use tracing::{debug, error, instrument, trace};
 
 use crate::{
     api::{
@@ -115,8 +115,8 @@ use crate::{
     store::{
         fs::{
             bao_file::{
-                BaoFileStorage, BaoFileStorageSubscriber, CompleteStorage, DataReader,
-                OutboardReader,
+                open_external_data, BaoFileOpenError, BaoFileStorage, BaoFileStorageSubscriber,
+                CompleteStorage, DataReader, OutboardReader,
             },
             util::entity_manager::{self, ActiveEntityState},
         },
@@ -296,9 +296,30 @@ impl SyncEntityApi for HashContext {
                     match self.global.db.get(self.id).await {
                         Ok(state) => match BaoFileStorage::open(state, self).await {
                             Ok(handle) => handle,
-                            Err(_) => BaoFileStorage::Poisoned,
+                            Err(BaoFileOpenError::ExternalDataMissing) => {
+                                debug!(
+                                    hash = %self.id.fmt_short(),
+                                    "external blob data is no longer available"
+                                );
+                                BaoFileStorage::NonExisting
+                            }
+                            Err(BaoFileOpenError::Storage(cause)) => {
+                                error!(
+                                    hash = %self.id.fmt_short(),
+                                    ?cause,
+                                    "failed to open blob storage"
+                                );
+                                BaoFileStorage::Poisoned
+                            }
                         },
-                        Err(_) => BaoFileStorage::Poisoned,
+                        Err(cause) => {
+                            error!(
+                                hash = %self.id.fmt_short(),
+                                ?cause,
+                                "failed to load blob metadata"
+                            );
+                            BaoFileStorage::Poisoned
+                        }
                     }
                 };
                 self.state.send_replace(state);
@@ -991,7 +1012,7 @@ impl EntityApi for HashContext {
     async fn persist(&self) {
         self.state.send_if_modified(|guard| {
             let hash = &self.id;
-            let BaoFileStorage::Partial(fs) = guard.take() else {
+            let Some(fs) = guard.take_partial() else {
                 return false;
             };
             let path = self.global.options.path.bitfield_path(hash);
@@ -1252,15 +1273,11 @@ async fn export_path_impl(
             MemOrFile::File((ctx.options().path.data_path(&cmd.hash), size)),
             vec![],
         ),
-        DataLocation::External(paths, size) => (
-            MemOrFile::File((
-                paths.first().cloned().ok_or_else(|| {
-                    io::Error::new(io::ErrorKind::NotFound, "no external data path")
-                })?,
-                size,
-            )),
-            paths,
-        ),
+        DataLocation::External(paths, size) => {
+            let (source_path, _source) =
+                open_external_data(&paths).map_err(BaoFileOpenError::into_io_error)?;
+            (MemOrFile::File((source_path, size)), paths)
+        }
     };
     let size = match &data {
         MemOrFile::Mem(data) => data.len() as u64,
@@ -1505,7 +1522,7 @@ pub mod tests {
 
     use super::*;
     use crate::{
-        api::blobs::Bitfield,
+        api::blobs::{Bitfield, ExportMode, ExportOptions},
         store::{
             util::{read_checksummed, tests::create_n0_bao, SliceInfoExt, Tag},
             IROH_BLOCK_SIZE,
@@ -1569,6 +1586,107 @@ pub mod tests {
             store.import_bao_bytes(hash, ranges, bao).await?;
             task.await??;
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_external_data_uses_remaining_candidate_after_restart() -> TestResult<()> {
+        let testdir = tempfile::tempdir()?;
+        let db_dir = testdir.path().join("db");
+        let first = testdir.path().join("first.bin");
+        let second = testdir.path().join("second.bin");
+        let exported = testdir.path().join("exported.bin");
+        let data = test_data(1024 * 16 + 1);
+        let hash = Hash::new(&data);
+
+        {
+            let store = FsStore::load(&db_dir).await?;
+            let tag = store.add_bytes(data.clone()).await?;
+            assert_eq!(tag.hash, hash);
+            store
+                .export_with_opts(ExportOptions {
+                    hash,
+                    mode: ExportMode::TryReference,
+                    target: first.clone(),
+                })
+                .await?;
+            store
+                .export_with_opts(ExportOptions {
+                    hash,
+                    mode: ExportMode::TryReference,
+                    target: second.clone(),
+                })
+                .await?;
+            store.sync_db().await?;
+            store.shutdown().await?;
+        }
+
+        fs::remove_file(first)?;
+        let store = FsStore::load(&db_dir).await?;
+        let observed = store.observe(hash).await?;
+        assert!(observed.is_complete());
+        store.export(hash, &exported).await?;
+        assert_eq!(fs::read(exported)?, data);
+        store.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_missing_external_data_is_recoverable() -> TestResult<()> {
+        let testdir = tempfile::tempdir()?;
+        let db_dir = testdir.path().join("db");
+        let external = testdir.path().join("external.bin");
+        let data = test_data(1024 * 16 + 1);
+        let hash = Hash::new(&data);
+
+        {
+            let store = FsStore::load(&db_dir).await?;
+            let tag = store.add_bytes(data.clone()).await?;
+            assert_eq!(tag.hash, hash);
+            store
+                .export_with_opts(ExportOptions {
+                    hash,
+                    mode: ExportMode::TryReference,
+                    target: external.clone(),
+                })
+                .await?;
+            store.sync_db().await?;
+            store.shutdown().await?;
+        }
+
+        fs::remove_file(external)?;
+        let store = FsStore::load(&db_dir).await?;
+        let missing = store.observe(hash).await?;
+        assert!(missing.is_empty());
+
+        let recovered = store.add_bytes(data).await?;
+        assert_eq!(recovered.hash, hash);
+        assert!(store.observe(hash).await?.is_complete());
+        store.shutdown().await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_missing_owned_data_terminates_observe_without_panicking() -> TestResult<()> {
+        let testdir = tempfile::tempdir()?;
+        let db_dir = testdir.path().join("db");
+        let data = test_data(1024 * 16 + 1);
+        let hash = Hash::new(&data);
+
+        {
+            let store = FsStore::load(&db_dir).await?;
+            let tag = store.add_bytes(data).await?;
+            assert_eq!(tag.hash, hash);
+            store.sync_db().await?;
+            store.shutdown().await?;
+        }
+
+        let data_path = Options::new(&db_dir).path.data_path(&hash);
+        fs::remove_file(data_path)?;
+
+        let store = FsStore::load(&db_dir).await?;
+        assert!(store.observe(hash).await.is_err());
+        store.shutdown().await?;
         Ok(())
     }
 

--- a/src/store/fs/bao_file.rs
+++ b/src/store/fs/bao_file.rs
@@ -3,7 +3,7 @@ use std::{
     fs::{File, OpenOptions},
     io,
     ops::Deref,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use bao_tree::{
@@ -21,7 +21,7 @@ use derive_more::Debug;
 use irpc::channel::mpsc;
 use n0_error::{Result, StdResultExt};
 use tokio::sync::watch;
-use tracing::{debug, info, trace};
+use tracing::{debug, info, trace, warn};
 
 use super::{
     entry_state::{DataLocation, EntryState, OutboardLocation},
@@ -128,6 +128,83 @@ fn max_offset(batch: &[BaoContentItem]) -> u64 {
         })
         .max()
         .unwrap_or(0)
+}
+
+#[derive(Debug)]
+pub(super) enum BaoFileOpenError {
+    ExternalDataMissing,
+    Storage(io::Error),
+}
+
+impl fmt::Display for BaoFileOpenError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::ExternalDataMissing => f.write_str("all external data paths are missing"),
+            Self::Storage(cause) => cause.fmt(f),
+        }
+    }
+}
+
+impl std::error::Error for BaoFileOpenError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::ExternalDataMissing => None,
+            Self::Storage(cause) => Some(cause),
+        }
+    }
+}
+
+impl From<io::Error> for BaoFileOpenError {
+    fn from(value: io::Error) -> Self {
+        Self::Storage(value)
+    }
+}
+
+impl BaoFileOpenError {
+    pub(super) fn into_io_error(self) -> io::Error {
+        match self {
+            Self::ExternalDataMissing => io::Error::new(
+                io::ErrorKind::NotFound,
+                "all external data paths are missing",
+            ),
+            Self::Storage(cause) => cause,
+        }
+    }
+}
+
+pub(super) fn open_external_data(
+    paths: &[PathBuf],
+) -> std::result::Result<(PathBuf, File), BaoFileOpenError> {
+    if paths.is_empty() {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            "external data location has no paths",
+        )
+        .into());
+    }
+
+    let mut first_storage_error = None;
+    for path in paths {
+        match File::open(path) {
+            Ok(file) => return Ok((path.clone(), file)),
+            Err(cause) if cause.kind() == io::ErrorKind::NotFound => {}
+            Err(cause) if first_storage_error.is_none() => {
+                first_storage_error = Some(io::Error::new(
+                    cause.kind(),
+                    format!(
+                        "failed to open external data path {}: {cause}",
+                        path.display()
+                    ),
+                ));
+            }
+            Err(_) => {}
+        }
+    }
+
+    match first_storage_error {
+        Some(cause) => Err(BaoFileOpenError::Storage(cause)),
+        None => Err(BaoFileOpenError::ExternalDataMissing),
+    }
 }
 
 /// A file storage for an incomplete bao file.
@@ -394,22 +471,17 @@ impl PartialMemStorage {
 }
 
 impl BaoFileStorage {
-    pub fn bitfield(&self) -> Bitfield {
-        match self {
-            BaoFileStorage::Initial => {
-                panic!("initial storage should not be used")
-            }
-            BaoFileStorage::Loading => {
-                panic!("loading storage should not be used")
-            }
-            BaoFileStorage::NonExisting => Bitfield::empty(),
-            BaoFileStorage::PartialMem(x) => x.bitfield.clone(),
-            BaoFileStorage::Partial(x) => x.bitfield.clone(),
-            BaoFileStorage::Complete(x) => Bitfield::complete(x.data.size()),
+    fn observed_bitfield(&self) -> io::Result<Option<Bitfield>> {
+        Ok(match self {
+            BaoFileStorage::Initial | BaoFileStorage::Loading => None,
+            BaoFileStorage::NonExisting => Some(Bitfield::empty()),
+            BaoFileStorage::PartialMem(x) => Some(x.bitfield.clone()),
+            BaoFileStorage::Partial(x) => Some(x.bitfield.clone()),
+            BaoFileStorage::Complete(x) => Some(Bitfield::complete(x.data.size())),
             BaoFileStorage::Poisoned => {
-                panic!("poisoned storage should not be used")
+                return Err(io::Error::other("poisoned storage"));
             }
-        }
+        })
     }
 
     pub(super) fn write_batch(
@@ -519,6 +591,16 @@ impl BaoFileStorage {
     pub fn take(&mut self) -> Self {
         std::mem::replace(self, BaoFileStorage::Poisoned)
     }
+
+    pub(super) fn take_partial(&mut self) -> Option<PartialFileStorage> {
+        if !matches!(self, Self::Partial(_)) {
+            return None;
+        }
+        let Self::Partial(storage) = self.take() else {
+            unreachable!("storage variant was checked before take")
+        };
+        Some(storage)
+    }
 }
 
 /// A cheaply cloneable handle to a bao file.
@@ -574,7 +656,10 @@ impl ReadAt for OutboardReader {
 }
 
 impl BaoFileStorage {
-    pub async fn open(state: Option<EntryState<Bytes>>, ctx: &HashContext) -> io::Result<Self> {
+    pub async fn open(
+        state: Option<EntryState<Bytes>>,
+        ctx: &HashContext,
+    ) -> std::result::Result<Self, BaoFileOpenError> {
         let hash = &ctx.id;
         let options = &ctx.global.options;
         Ok(match state {
@@ -590,10 +675,7 @@ impl BaoFileStorage {
                         MemOrFile::File(FixedSize::new(file, size))
                     }
                     DataLocation::External(paths, size) => {
-                        let Some(path) = paths.into_iter().next() else {
-                            return Err(io::Error::other("no external data path"));
-                        };
-                        let file = std::fs::File::open(&path)?;
+                        let (_, file) = open_external_data(&paths)?;
                         MemOrFile::File(FixedSize::new(file, size))
                     }
                 };
@@ -708,12 +790,12 @@ impl BaoFileStorageSubscriber {
     ///
     /// Returns an error if sending fails, or if the last sender is dropped
     pub async fn forward(mut self, mut tx: mpsc::Sender<Bitfield>) -> Result<()> {
-        let value = self.receiver.borrow().bitfield();
+        let value = self.next_observed_bitfield(&mut tx).await?;
         tx.send(value).await?;
         loop {
             self.update_or_closed(&mut tx).await?;
-            let value = self.receiver.borrow().bitfield();
-            tx.send(value.clone()).await?;
+            let value = self.next_observed_bitfield(&mut tx).await?;
+            tx.send(value).await?;
         }
     }
 
@@ -722,18 +804,33 @@ impl BaoFileStorageSubscriber {
     /// Returns an error if sending fails, or if the last sender is dropped
     #[allow(dead_code)]
     pub async fn forward_delta(mut self, mut tx: mpsc::Sender<Bitfield>) -> Result<()> {
-        let value = self.receiver.borrow().bitfield();
+        let value = self.next_observed_bitfield(&mut tx).await?;
         let mut old = value.clone();
         tx.send(value).await?;
         loop {
             self.update_or_closed(&mut tx).await?;
-            let new = self.receiver.borrow().bitfield();
+            let new = self.next_observed_bitfield(&mut tx).await?;
             let diff = old.diff(&new);
             if diff.is_empty() {
                 continue;
             }
             tx.send(diff).await?;
             old = new;
+        }
+    }
+
+    async fn next_observed_bitfield(
+        &mut self,
+        tx: &mut mpsc::Sender<Bitfield>,
+    ) -> Result<Bitfield> {
+        loop {
+            let value = { self.receiver.borrow().observed_bitfield() }
+                .inspect_err(|cause| warn!(?cause, "terminating observe stream for broken storage"))
+                .anyerr()?;
+            if let Some(value) = value {
+                return Ok(value);
+            }
+            self.update_or_closed(tx).await?;
         }
     }
 
@@ -745,5 +842,114 @@ impl BaoFileStorageSubscriber {
             }
             e = self.receiver.changed() => Ok(e.anyerr()?),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Read;
+
+    use irpc::channel::mpsc;
+    use testresult::TestResult;
+    use tokio::sync::watch;
+
+    use super::*;
+
+    #[test]
+    fn observe_state_distinguishes_transitional_missing_and_broken() {
+        assert_eq!(BaoFileStorage::Initial.observed_bitfield().unwrap(), None);
+        assert_eq!(BaoFileStorage::Loading.observed_bitfield().unwrap(), None);
+        assert_eq!(
+            BaoFileStorage::NonExisting.observed_bitfield().unwrap(),
+            Some(Bitfield::empty())
+        );
+        assert!(BaoFileStorage::Poisoned.observed_bitfield().is_err());
+    }
+
+    #[test]
+    fn take_partial_does_not_modify_other_states() {
+        let mut complete = BaoFileStorage::Complete(CompleteStorage {
+            data: MemOrFile::Mem(Bytes::from_static(b"complete")),
+            outboard: MemOrFile::empty(),
+        });
+        assert!(complete.take_partial().is_none());
+        assert!(matches!(complete, BaoFileStorage::Complete(_)));
+
+        let mut missing = BaoFileStorage::NonExisting;
+        assert!(missing.take_partial().is_none());
+        assert!(matches!(missing, BaoFileStorage::NonExisting));
+    }
+
+    #[test]
+    fn external_data_uses_the_first_available_candidate() -> TestResult<()> {
+        let temp = tempfile::tempdir()?;
+        let missing = temp.path().join("missing.bin");
+        let available = temp.path().join("available.bin");
+        std::fs::write(&available, b"available")?;
+
+        let (selected, mut file) = open_external_data(&[missing, available.clone()])?;
+        let mut data = Vec::new();
+        file.read_to_end(&mut data)?;
+
+        assert_eq!(selected, available);
+        assert_eq!(data, b"available");
+        Ok(())
+    }
+
+    #[test]
+    fn external_data_distinguishes_missing_from_invalid_metadata() {
+        let temp = tempfile::tempdir().expect("temporary directory should be available");
+        let missing = temp.path().join("missing.bin");
+        assert!(matches!(
+            open_external_data(&[missing]),
+            Err(BaoFileOpenError::ExternalDataMissing)
+        ));
+
+        let Err(BaoFileOpenError::Storage(cause)) = open_external_data(&[]) else {
+            panic!("empty external path metadata must be invalid")
+        };
+        assert_eq!(cause.kind(), io::ErrorKind::InvalidData);
+    }
+
+    #[tokio::test]
+    async fn subscriber_waits_for_loading_to_stabilize() {
+        let (state_tx, state_rx) = watch::channel(BaoFileStorage::Loading);
+        let subscriber = BaoFileStorageSubscriber::new(state_rx);
+        let (tx, mut rx) = mpsc::channel(1);
+        let forward = tokio::spawn(async move { subscriber.forward(tx).await });
+
+        tokio::task::yield_now().await;
+        assert!(!forward.is_finished());
+
+        state_tx.send_replace(BaoFileStorage::NonExisting);
+        let first = rx
+            .recv()
+            .await
+            .expect("receiver should stay open")
+            .expect("stable missing state should be emitted");
+        assert!(first.is_empty());
+
+        drop(rx);
+        assert!(forward
+            .await
+            .expect("subscriber task should not panic")
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn subscriber_terminates_for_poisoned_storage() {
+        let (_state_tx, state_rx) = watch::channel(BaoFileStorage::Poisoned);
+        let subscriber = BaoFileStorageSubscriber::new(state_rx);
+        let (tx, mut rx) = mpsc::channel(1);
+        let result = tokio::spawn(async move { subscriber.forward(tx).await })
+            .await
+            .expect("subscriber task should not panic");
+
+        assert!(result.is_err());
+        assert!(rx
+            .recv()
+            .await
+            .expect("local receiver should stay valid")
+            .is_none());
     }
 }


### PR DESCRIPTION
Closes #233.

## Summary

- prevent `HashContext::persist()` from destructively replacing non-`Partial` storage with `Poisoned`
- distinguish missing external references from store-owned corruption and metadata/I/O failures
- try all external data candidates during load and export
- wait through `Initial`/`Loading`, emit empty only for `NonExisting`, and terminate observe for `Poisoned`

This keeps an empty bitfield meaning “valid entry with no verified data” and uses the existing stream failure path for broken entries, following the design discussion in #214.

## Recovery semantics

- all external paths missing: `NonExisting`, allowing a normal re-fetch/import
- owned data/outboard missing, invalid external metadata, permission/DB/I/O failure: terminal `Poisoned`
- first external path missing but a later candidate is readable: use the later candidate

## Tests

- safe partial extraction without mutating complete/missing states
- transitional observe waiting and poisoned observe termination
- missing vs invalid external metadata
- external candidate fallback across restart for observe and export
- all external files removed followed by successful re-import
- missing store-owned data returns an observe error without panicking

Verified with:

- `cargo test --all-features` (103 unit passed, 2 ignored; 6 integration passed; 17 doctests passed)
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`