### PR TITLE
fix: release fs store runtime workers on shutdown

### DIFF
--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -835,9 +835,7 @@ impl Drop for RtWrapper {
     fn drop(&mut self) {
         if let Some(rt) = self.0.take() {
             trace!("dropping tokio runtime");
-            tokio::task::block_in_place(|| {
-                drop(rt);
-            });
+            rt.shutdown_background();
             trace!("dropped tokio runtime");
         }
     }
@@ -1511,6 +1509,33 @@ pub mod tests {
             IROH_BLOCK_SIZE,
         },
     };
+
+    #[cfg(target_os = "linux")]
+    #[tokio::test(flavor = "current_thread")]
+    async fn shutdown_releases_owned_runtime_threads() -> TestResult<()> {
+        let directory = tempfile::tempdir()?;
+        for _ in 0..3 {
+            let store = FsStore::load(directory.path()).await?;
+            store.shutdown().await?;
+            drop(store);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let warmed_threads = fs::read_dir("/proc/self/task")?.count();
+
+        for _ in 0..8 {
+            let store = FsStore::load(directory.path()).await?;
+            store.shutdown().await?;
+            drop(store);
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        let final_threads = fs::read_dir("/proc/self/task")?.count();
+
+        assert!(
+            final_threads <= warmed_threads + 1,
+            "runtime workers grew across settled shutdowns: warmed={warmed_threads}, final={final_threads}"
+        );
+        Ok(())
+    }
 
     /// Interesting sizes for testing.
     pub const INTERESTING_SIZES: [usize; 8] = [


### PR DESCRIPTION
## Summary

- shut down the FsStore-owned Tokio runtime in the background instead of synchronously dropping it from one of its own worker threads
- add a Linux regression that repeatedly loads and shuts down one filesystem store and verifies worker threads plateau

## Root cause

`RtWrapper::drop` runs as the filesystem actor exits, on the runtime it owns. Synchronously dropping that runtime from `block_in_place` leaves one `iroh-blob-store-*` worker blocked per clean shutdown. Repeated same-process reopen cycles therefore grow threads and RSS linearly.

`Runtime::shutdown_background` is the Tokio-supported non-blocking shutdown path when waiting for runtime tasks is not possible. FsStore already drains its handles and joins its actor tasks before `RtWrapper` is dropped.

## Verification

- regression fails against v0.103.0 with 8 additional retained workers after 8 settled shutdowns
- regression passes with this change
- `cargo fmt --all -- --check`
- `cargo test --all-features store::fs::tests::shutdown_releases_owned_runtime_threads -- --exact --nocapture`