### PR TITLE
fix(gc): swap enumeration order in gc mark phase to avoid TOCTOU bug

### DIFF
--- a/src/store/gc.rs
+++ b/src/store/gc.rs
@@ -47,18 +47,18 @@ pub(super) async fn gc_mark_task(
         };
     }
     let mut roots = HashSet::new();
+    trace!("traversing temp roots");
+    let mut tts = store.tags().list_temp_tags().await?;
+    while let Some(tt) = tts.next().await {
+        trace!("adding temp root {:?}", tt);
+        roots.insert(tt);
+    }
     trace!("traversing tags");
     let mut tags = store.tags().list().await?;
     while let Some(tag) = tags.next().await {
         let info = tag?;
         trace!("adding root {:?} {:?}", info.name, info.hash_and_format());
         roots.insert(info.hash_and_format());
-    }
-    trace!("traversing temp roots");
-    let mut tts = store.tags().list_temp_tags().await?;
-    while let Some(tt) = tts.next().await {
-        trace!("adding temp root {:?}", tt);
-        roots.insert(tt);
     }
     for HashAndFormat { hash, format } in roots {
         // we need to do this for all formats except raw


### PR DESCRIPTION
## Description

Currently, it is possible for the gc to accidentally delete blobs that were tagged using something like:
```rust
let tag = store.blobs().add_slice(buffer).with_named_tag(b"my-tag-name").await?;
```
This can happen due to a TOCTOU bug in the mark phase of the gc (see #247). Because named tags are enumerated before temp tags in a check for blob liveness, it is possible to queue the following order of irpc messages:

|Action|Origin|
|---|---|
|ListNamedTags|GC|
|SetNamedTag|AddProgress|
|ClearTempTag|AddProgress|
|ListTempTags|GC|

The gc is completely blind to the tag added in this sequence of messages. The elegant fix is to swap the order of enumeration into the following:

|Action|Origin|
|---|---|
|ListTempTags|GC|
|SetNamedTag|AddProgress|
|ClearTempTag|AddProgress|
|ListNamedTags|GC|

Now, regardless of whether the temp tag is seen by the gc or not, the named tag is guaranteed to be seen by the gc and thus it becomes impossible to accidentally delete blobs as explained in the original problem statement.

Fixes #247.

## Breaking Changes


## Notes & open questions

<!-- Any notes, remarks or open questions you have to make about the PR. -->
Does it make sense to try and write a unit test for this bug to prevent it from returning in the future? Or does it suffice to add internal documentation to the code?

## Change checklist

- [x] Self-review.
- [x] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
