### PR TITLE
fix: enforce the per-request-type event mask, not always mask.get

### DIFF
--- a/examples/limit.rs
+++ b/examples/limit.rs
@@ -24,8 +24,8 @@ use common::setup_logging;
 use iroh::{endpoint::presets, protocol::Router, EndpointAddr, EndpointId, SecretKey};
 use iroh_blobs::{
     provider::events::{
-        AbortReason, ConnectMode, EventMask, EventSender, ProviderMessage, RequestMode,
-        ThrottleMode,
+        AbortReason, ConnectMode, EventMask, EventSender, ObserveMode, ProviderMessage,
+        RequestMode, ThrottleMode,
     },
     store::mem::MemStore,
     ticket::BlobTicket,
@@ -114,23 +114,45 @@ fn limit_by_hash(allowed_hashes: HashSet<Hash>) -> EventSender {
         // with OK or not OK depending on the hash. We do not want detailed
         // events once it has been decided to handle a request.
         get: RequestMode::Intercept,
+        // Every mode is per request type, so an allowlist has to cover *all* the
+        // request types that can read the store, not just `get`. Leaving these at
+        // their `DEFAULT` of "no events" would mean the check below is skipped for
+        // them and a peer just asks for the blob by another name.
+        get_many: RequestMode::Intercept,
+        observe: ObserveMode::Intercept,
         ..EventMask::DEFAULT
     };
     let (tx, mut rx) = EventSender::channel(32, mask);
     n0_future::task::spawn(async move {
+        let allowed = |hash: &Hash| {
+            if allowed_hashes.contains(hash) {
+                println!("Request for hash {hash} allowed");
+                Ok(())
+            } else {
+                println!("Request for hash {hash} not allowed");
+                Err(AbortReason::Permission)
+            }
+        };
         while let Some(msg) = rx.recv().await {
-            if let ProviderMessage::GetRequestReceived(msg) = msg {
-                let res = if !msg.request.ranges.is_blob() {
-                    println!("HashSeq request not allowed");
-                    Err(AbortReason::Permission)
-                } else if !allowed_hashes.contains(&msg.request.hash) {
-                    println!("Request for hash {} not allowed", msg.request.hash);
-                    Err(AbortReason::Permission)
-                } else {
-                    println!("Request for hash {} allowed", msg.request.hash);
-                    Ok(())
-                };
-                msg.tx.send(res).await.ok();
+            match msg {
+                ProviderMessage::GetRequestReceived(msg) => {
+                    let res = if !msg.request.ranges.is_blob() {
+                        println!("HashSeq request not allowed");
+                        Err(AbortReason::Permission)
+                    } else {
+                        allowed(&msg.request.hash)
+                    };
+                    msg.tx.send(res).await.ok();
+                }
+                ProviderMessage::GetManyRequestReceived(msg) => {
+                    let res = msg.request.hashes.iter().try_for_each(&allowed);
+                    msg.tx.send(res).await.ok();
+                }
+                ProviderMessage::ObserveRequestReceived(msg) => {
+                    let res = allowed(&msg.request.hash);
+                    msg.tx.send(res).await.ok();
+                }
+                _ => {}
             }
         }
     });

--- a/examples/random_store.rs
+++ b/examples/random_store.rs
@@ -5,7 +5,7 @@ use clap::{Parser, Subcommand};
 use iroh::{address_lookup::MemoryLookup, endpoint::presets, SecretKey};
 use iroh_blobs::{
     api::downloader::Shuffled,
-    provider::events::{AbortReason, EventMask, EventSender, ProviderMessage},
+    provider::events::{AbortReason, EventMask, EventSender, ProviderMessage, RequestMode},
     store::fs::FsStore,
     test::{add_hash_sequences, create_random_blobs},
     HashAndFormat,
@@ -102,7 +102,14 @@ pub fn get_or_generate_secret_key() -> Result<SecretKey> {
 }
 
 pub fn dump_provider_events(allow_push: bool) -> (tokio::task::JoinHandle<()>, EventSender) {
-    let (tx, mut rx) = EventSender::channel(100, EventMask::ALL_READONLY);
+    let mask = EventMask {
+        // `ALL_READONLY` leaves `push` disabled, which would reject every push before
+        // the handler below ever sees it and make `--allow-push` a no-op. The handler
+        // is the thing that decides, so the mask has to hand the request to it.
+        push: RequestMode::InterceptLog,
+        ..EventMask::ALL_READONLY
+    };
+    let (tx, mut rx) = EventSender::channel(100, mask);
     fn dump_updates<T: RpcMessage>(mut rx: irpc::channel::mpsc::Receiver<T>) {
         tokio::spawn(async move {
             while let Ok(Some(update)) = rx.recv().await {

--- a/src/provider.rs
+++ b/src/provider.rs
@@ -148,7 +148,7 @@ impl<R: RecvStream, W: SendStream> StreamPair<R, W> {
         f: impl FnOnce() -> GetRequest,
     ) -> Result<RequestTracker, ProgressError> {
         self.events
-            .request(f, self.connection_id, self.reader.id())
+            .get_request(f, self.connection_id, self.reader.id())
             .await
     }
 
@@ -157,7 +157,7 @@ impl<R: RecvStream, W: SendStream> StreamPair<R, W> {
         f: impl FnOnce() -> GetManyRequest,
     ) -> Result<RequestTracker, ProgressError> {
         self.events
-            .request(f, self.connection_id, self.reader.id())
+            .get_many_request(f, self.connection_id, self.reader.id())
             .await
     }
 
@@ -166,7 +166,7 @@ impl<R: RecvStream, W: SendStream> StreamPair<R, W> {
         f: impl FnOnce() -> PushRequest,
     ) -> Result<RequestTracker, ProgressError> {
         self.events
-            .request(f, self.connection_id, self.reader.id())
+            .push_request(f, self.connection_id, self.reader.id())
             .await
     }
 
@@ -175,7 +175,7 @@ impl<R: RecvStream, W: SendStream> StreamPair<R, W> {
         f: impl FnOnce() -> ObserveRequest,
     ) -> Result<RequestTracker, ProgressError> {
         self.events
-            .request(f, self.connection_id, self.reader.id())
+            .observe_request(f, self.connection_id, self.reader.id())
             .await
     }
 

--- a/src/provider/events.rs
+++ b/src/provider/events.rs
@@ -43,6 +43,16 @@ pub enum ObserveMode {
     Intercept,
 }
 
+impl From<ObserveMode> for RequestMode {
+    fn from(value: ObserveMode) -> Self {
+        match value {
+            ObserveMode::None => RequestMode::None,
+            ObserveMode::Notify => RequestMode::Notify,
+            ObserveMode::Intercept => RequestMode::Intercept,
+        }
+    }
+}
+
 /// Request mode for all data related requests.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[repr(u8)]
@@ -435,12 +445,65 @@ impl EventSender {
         Ok(())
     }
 
+    /// A get request was received.
+    pub(crate) async fn get_request(
+        &self,
+        f: impl FnOnce() -> GetRequest,
+        connection_id: u64,
+        request_id: u64,
+    ) -> Result<RequestTracker, ProgressError> {
+        self.request(f, self.mask.get, connection_id, request_id)
+            .await
+    }
+
+    /// A get_many request was received.
+    pub(crate) async fn get_many_request(
+        &self,
+        f: impl FnOnce() -> GetManyRequest,
+        connection_id: u64,
+        request_id: u64,
+    ) -> Result<RequestTracker, ProgressError> {
+        self.request(f, self.mask.get_many, connection_id, request_id)
+            .await
+    }
+
+    /// A push request was received.
+    ///
+    /// Note that a push writes to the local store, which is why
+    /// [`EventMask::DEFAULT`] disables it.
+    pub(crate) async fn push_request(
+        &self,
+        f: impl FnOnce() -> PushRequest,
+        connection_id: u64,
+        request_id: u64,
+    ) -> Result<RequestTracker, ProgressError> {
+        self.request(f, self.mask.push, connection_id, request_id)
+            .await
+    }
+
+    /// An observe request was received.
+    pub(crate) async fn observe_request(
+        &self,
+        f: impl FnOnce() -> ObserveRequest,
+        connection_id: u64,
+        request_id: u64,
+    ) -> Result<RequestTracker, ProgressError> {
+        self.request(f, self.mask.observe.into(), connection_id, request_id)
+            .await
+    }
+
     /// Abstract request, to DRY the 3 to 4 request types.
     ///
     /// DRYing stuff with lots of bounds is no fun at all...
-    pub(crate) async fn request<Req>(
+    ///
+    /// `mode` is the [`RequestMode`] configured for this particular request type.
+    /// It must be passed in by the caller: reading it off the mask here would
+    /// have to pick one field, and so would silently apply the wrong policy to
+    /// the other three request types.
+    async fn request<Req>(
         &self,
         f: impl FnOnce() -> Req,
+        mode: RequestMode,
         connection_id: u64,
         request_id: u64,
     ) -> Result<RequestTracker, ProgressError>
@@ -459,7 +522,7 @@ impl EventSender {
     {
         let client = self.inner.as_ref();
         Ok(self.create_tracker((
-            match self.mask.get {
+            match mode {
                 RequestMode::None => RequestUpdates::None,
                 RequestMode::Notify if client.is_some() => {
                     let msg = RequestReceived {

--- a/src/provider/events.rs
+++ b/src/provider/events.rs
@@ -34,21 +34,33 @@ pub enum ConnectMode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[repr(u8)]
 pub enum ObserveMode {
-    /// We don't get notification of connect events at all.
+    /// We don't get observe request events at all.
     #[default]
     None,
-    /// We get a notification for connect events.
+    /// We get a notification for each observe request.
     Notify,
-    /// We get a request for connect events and can reject incoming connections.
+    /// We get a request for each observe request, and can reject it.
     Intercept,
+    /// Observe requests are completely disabled. All of them will be rejected.
+    ///
+    /// An observe response streams the local bitfield for a hash, i.e. exactly which
+    /// byte ranges of it this node holds, so a locked-down provider needs a way to
+    /// refuse them outright rather than only being able to intercept them.
+    Disabled,
 }
 
 impl From<ObserveMode> for RequestMode {
     fn from(value: ObserveMode) -> Self {
+        // The `*Log` variants, not the plain ones: an observe request transfers no
+        // blobs, so it never produces per-blob transfer events, and the completion
+        // update is the only update it can ever emit. Mapping to `Notify`/`Intercept`
+        // would make the request tracker `Disabled`, and a handler waiting on
+        // `RequestUpdate::Completed` for an observe request would wait forever.
         match value {
             ObserveMode::None => RequestMode::None,
-            ObserveMode::Notify => RequestMode::Notify,
-            ObserveMode::Intercept => RequestMode::Intercept,
+            ObserveMode::Notify => RequestMode::NotifyLog,
+            ObserveMode::Intercept => RequestMode::InterceptLog,
+            ObserveMode::Disabled => RequestMode::Disabled,
         }
     }
 }

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -19,7 +19,9 @@ use crate::{
     hashseq::HashSeq,
     net_protocol::BlobsProtocol,
     protocol::{ChunkRangesSeq, GetManyRequest, ObserveRequest, PushRequest},
-    provider::events::{AbortReason, EventMask, EventSender, ProviderMessage, RequestUpdate},
+    provider::events::{
+        AbortReason, EventMask, EventSender, ProviderMessage, RequestMode, RequestUpdate,
+    },
     store::{
         fs::{
             tests::{test_data, INTERESTING_SIZES},
@@ -341,11 +343,21 @@ async fn two_nodes_get_many_mem() -> TestResult<()> {
     two_nodes_get_many(r1, &store1, r2, &store2).await
 }
 
+/// [`EventMask::ALL_READONLY`] with push enabled.
+///
+/// There is deliberately no such constant in the crate itself — push writes to the local
+/// store, so enabling it has to be a conscious act by the operator. These tests are that
+/// conscious act: they intercept `PushRequestReceived` and admit the pushing node.
+const ALL_WITH_PUSH: EventMask = EventMask {
+    push: RequestMode::InterceptLog,
+    ..EventMask::ALL_READONLY
+};
+
 fn event_handler(
     allowed_nodes: impl IntoIterator<Item = EndpointId>,
 ) -> (EventSender, watch::Receiver<usize>, AbortOnDropHandle<()>) {
     let (count_tx, count_rx) = tokio::sync::watch::channel(0usize);
-    let (events_tx, mut events_rx) = EventSender::channel(16, EventMask::ALL_READONLY);
+    let (events_tx, mut events_rx) = EventSender::channel(16, ALL_WITH_PUSH);
     let allowed_nodes = allowed_nodes.into_iter().collect::<HashSet<_>>();
     let task = AbortOnDropHandle::new(n0_future::task::spawn(async move {
         while let Some(event) = events_rx.recv().await {
@@ -431,6 +443,117 @@ async fn two_nodes_push_blobs_mem() -> TestResult<()> {
     sp1.add_endpoint_info(r2.endpoint().addr());
     sp2.add_endpoint_info(r1.endpoint().addr());
     two_nodes_push_blobs(r1, &store1, r2, &store2, count_rx).await
+}
+
+/// A push must be refused when the event mask disables it.
+///
+/// [`EventMask::DEFAULT`] sets `push: RequestMode::Disabled` precisely because a push
+/// writes to the local store, so an unauthorized peer must not be able to place blobs of
+/// its choosing into ours.
+///
+/// The pusher cannot observe the refusal: `execute_push_sink` stops its receive stream
+/// and returns `Stats::default()` unconditionally, and the provider handles each stream
+/// in a detached task, so a rejection never surfaces as a connection- or call-level
+/// error. The property under test is therefore the one that actually matters — the blob
+/// must not land in the receiving store. `allow` is a control: pushing the same blob to
+/// a node that permits pushes proves the push path works in this setup, so a passing
+/// "denied" assertion cannot be an artifact of a push that never happened.
+async fn push_is_rejected_when_disabled(
+    pusher: Router,
+    pusher_store: &Store,
+    deny: Router,
+    deny_store: &Store,
+    allow: Router,
+    allow_store: &Store,
+    mut allow_count_rx: watch::Receiver<usize>,
+) -> TestResult<()> {
+    let size = 1024;
+    let tt = pusher_store.add_bytes(test_data(size)).await?;
+    let hash = tt.hash;
+    let request = PushRequest::new(hash, ChunkRangesSeq::root());
+
+    // The connections must outlive the pushes: `execute_push_sink` returns once it has
+    // called `finish()`, but dropping the `Connection` at that point tears down the
+    // still-in-flight stream and the receiver never finishes importing.
+    let mut conns = Vec::new();
+    for target in [&deny, &allow] {
+        let conn = pusher
+            .endpoint()
+            .connect(target.endpoint().addr(), crate::ALPN)
+            .await?;
+        pusher_store
+            .remote()
+            .execute_push_sink(conn.clone(), request.clone(), Drain)
+            .await?;
+        conns.push(conn);
+    }
+
+    // The permissive node completing its push bounds the wait for the denying one:
+    // both were pushed over loopback, the denying one first.
+    allow_count_rx.changed().await?;
+    assert_eq!(
+        allow_store.get_bytes(hash).await?,
+        test_data(size),
+        "control: a node that permits pushes must receive the blob"
+    );
+    assert!(
+        !deny_store.blobs().has(hash).await?,
+        "a push rejected by the event mask must not write to the receiving store"
+    );
+
+    tokio::try_join!(pusher.shutdown(), deny.shutdown(), allow.shutdown())?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn push_is_rejected_when_disabled_mem() -> TestResult<()> {
+    tracing_subscriber::fmt::try_init().ok();
+    let (r1, store1, sp1) = node_test_setup_mem().await?;
+    // `EventSender::DEFAULT` carries `EventMask::DEFAULT`, i.e. push disabled.
+    let (r_deny, store_deny, sp_deny) = node_test_setup_mem().await?;
+    let (events_tx, count_rx, _task) = event_handler([r1.endpoint().id()]);
+    let (r_allow, store_allow, sp_allow) = node_test_setup_with_events_mem(events_tx).await?;
+    for sp in [&sp1, &sp_deny, &sp_allow] {
+        sp.add_endpoint_info(r1.endpoint().addr());
+        sp.add_endpoint_info(r_deny.endpoint().addr());
+        sp.add_endpoint_info(r_allow.endpoint().addr());
+    }
+    push_is_rejected_when_disabled(
+        r1,
+        &store1,
+        r_deny,
+        &store_deny,
+        r_allow,
+        &store_allow,
+        count_rx,
+    )
+    .await
+}
+
+#[tokio::test]
+async fn push_is_rejected_when_disabled_fs() -> TestResult<()> {
+    tracing_subscriber::fmt::try_init().ok();
+    let testdir = tempfile::tempdir()?;
+    let (r1, store1, _, sp1) = node_test_setup_fs(testdir.path().join("a")).await?;
+    let (r_deny, store_deny, _, sp_deny) = node_test_setup_fs(testdir.path().join("deny")).await?;
+    let (events_tx, count_rx, _task) = event_handler([r1.endpoint().id()]);
+    let (r_allow, store_allow, _, sp_allow) =
+        node_test_setup_with_events_fs(testdir.path().join("allow"), events_tx).await?;
+    for sp in [&sp1, &sp_deny, &sp_allow] {
+        sp.add_endpoint_info(r1.endpoint().addr());
+        sp.add_endpoint_info(r_deny.endpoint().addr());
+        sp.add_endpoint_info(r_allow.endpoint().addr());
+    }
+    push_is_rejected_when_disabled(
+        r1,
+        &store1,
+        r_deny,
+        &store_deny,
+        r_allow,
+        &store_allow,
+        count_rx,
+    )
+    .await
 }
 
 pub async fn add_test_hash_seq(

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashSet, io, ops::Range, path::PathBuf};
+use std::{collections::HashSet, io, ops::Range, path::PathBuf, time::Duration};
 
 use bao_tree::ChunkRanges;
 use bytes::Bytes;
@@ -14,7 +14,10 @@ use tokio::sync::{mpsc, watch};
 use tracing::info;
 
 use crate::{
-    api::{blobs::Bitfield, Store},
+    api::{
+        blobs::{Bitfield, BlobStatus},
+        Store,
+    },
     get,
     hashseq::HashSeq,
     net_protocol::BlobsProtocol,
@@ -496,10 +499,26 @@ async fn push_is_rejected_when_disabled(
         test_data(size),
         "control: a node that permits pushes must receive the blob"
     );
-    assert!(
-        !deny_store.blobs().has(hash).await?,
-        "a push rejected by the event mask must not write to the receiving store"
-    );
+    // Nothing on the denying node is observable from here — a disabled request type
+    // emits no event, `execute_push_sink` does not wait for the receiver, and the
+    // provider imports on a detached task. Sampling once could therefore run before an
+    // accepted push had landed and pass on a broken mask, so keep sampling for a while:
+    // an accepted push over loopback lands well inside this window. `status`, not
+    // `has`: `has` is only true for a *complete* blob, so a rejection that arrived
+    // after some chunks had already been imported would leave attacker-chosen bytes in
+    // the store and still satisfy the assertion.
+    let deadline = tokio::time::Instant::now() + Duration::from_secs(1);
+    loop {
+        assert_eq!(
+            deny_store.blobs().status(hash).await?,
+            BlobStatus::NotFound,
+            "a push rejected by the event mask must not write to the receiving store"
+        );
+        if tokio::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
 
     tokio::try_join!(pusher.shutdown(), deny.shutdown(), allow.shutdown())?;
     Ok(())


### PR DESCRIPTION
## Description

`EventSender::request` is generic over the four request types but reads a single
hardcoded field for all of them (`src/provider/events.rs`):

```rust
Ok(self.create_tracker((
    match self.mask.get {          // for get, get_many, push AND observe
```

`mask.push`, `mask.get_many` and `mask.observe` are never read anywhere in the
crate — the only mask reads are `connected`, `get` and `throttle`. All four entry
points in `provider.rs` have byte-identical bodies calling the same generic.

The consequence is that `RequestMode::Disabled` never takes effect for push.
`RequestMode::None` — what `BlobsProtocol::new(&store, None)` installs via
`EventMask::DEFAULT` — means "allow, don't notify", so the `Disabled` arm
returning `ProgressError::Permission` is unreachable for push under every
configuration I could construct.

That contradicts the documented contract in three places: the `EventMask` docs
("push requests are disabled by default, as they can write to the local store"),
`DEFAULT` and `ALL_READONLY` both setting `push: RequestMode::Disabled`, and
`ALL_READONLY` explicitly declining to ship a push-enabled constant because it
"would risk misuse".

**Impact.** A peer that knows a node's `EndpointId` — a public identifier
distributed in tickets and gossip — can dial the blobs ALPN and push blobs of its
choosing into the store, which the node then serves to anyone presenting the
hash. Bounding it honestly: content is BLAKE3-verified against the hash the
pusher names, so existing blobs cannot be forged, substituted or corrupted. The
impact is unauthorized *write* and content injection — the node becomes a content
host for attacker-chosen data under the operator's IP and identity.

**Fix.** Thread the applicable `RequestMode` into `request` as a parameter,
supplied by four typed wrappers next to the mask itself. Observe maps through a
new `From<ObserveMode> for RequestMode`.

## Second commit: closing the gaps the first one opens

Reading the right field un-gates every config that had only ever set `mask.get`
and relied on the shared dispatch. **Two of your own examples do exactly that**,
so the first commit alone would ship a hole in the crate's own allowlist demo:

- `examples/limit.rs::limit_by_hash` is `get: Intercept, ..DEFAULT` and only
  answers `GetRequestReceived`. Today get_many and observe are intercepted
  through the same field and refused (the example never answers them, the
  dropped oneshot fails `rx.await??`). After the first commit they read
  `DEFAULT`'s `None` and are served unconditionally — a peer reads any blob by
  asking as a `GetManyRequest`, and probes bitfields with `ObserveRequest`. The
  example now answers all three with the same allowlist.
- `examples/random_store.rs` builds on `ALL_READONLY` and gates pushes on
  `--allow-push` inside the `PushRequestReceived` arm. `mask.push` is `Disabled`
  there, so after the first commit the mask rejects before the handler ever
  runs and the flag silently does nothing.

**I was wrong about observe** — the original text here claimed its behaviour was
unchanged because `ObserveMode` has no `Disabled` variant. It is wrong in both
directions:

- Observe currently reads `mask.get`, so `get: Disabled` *did* disable observe.
  After the change nothing can, and an observe response streams the local
  bitfield for a hash — exactly which byte ranges the node holds. Added
  `ObserveMode::Disabled`.
- `get: InterceptLog` gave observe an `Active` tracker; `Intercept -> Intercept`
  yields `Disabled`, so completion updates stop being delivered. An observe
  request transfers no blobs, so completion is the only update it can ever emit,
  and the plain variants drop it. The conversion now maps through the `*Log`
  variants.

The test in the first commit was also weaker than it read.
`allow_count_rx.changed()` does not synchronize the denying node at all —
nothing observes it, and a disabled request type emits no event — so the
assertion was a single early sample that would pass on a broken mask. `has` is
additionally false for a *partial* import, so a rejection arriving mid-transfer
would leave attacker-chosen bytes in the store and still pass. It now asserts
`BlobStatus::NotFound`, repeatedly, to a deadline.

## Breaking Changes

Behavioural, not API: **push now actually requires a mask that enables it.**

Your own tests were passing *because* of the bug — `event_handler` in
`src/tests.rs` used `ALL_READONLY` (which sets `push: Disabled`) and
`two_nodes_push_blobs_fs`/`_mem` asserted the pushed data arrived anyway. This PR
switches them to an explicitly push-enabled mask, which is the conscious act the
`ALL_READONLY` doc asks for. Any downstream relying on push under `DEFAULT` or
`ALL_READONLY` will see the same change, and I think that is the point of the
fix rather than a regression — but it is worth a release note.

Two smaller behavioural changes come with the second commit and are worth the
same note: `ObserveMode` gains a `Disabled` variant (additive, but the enum is
matched exhaustively inside the crate), and `ObserveMode::Notify`/`Intercept`
now deliver the completion update they used to get from `mask.get`'s `*Log`
setting.

## Notes & open questions

- Found during a security review of [our fork](https://github.com/holon-technologies/iroh),
  which imported iroh-blobs v0.103.0. Traced to `feat: Provider events refactor (#142)`
  (2025-09-11) — it looks like a copy-paste slip while DRYing the four per-type
  gates into one generic, not a deliberate choice.
- **This is already public**, which I regret: we fixed it in our fork and pushed
  before recognising it was inherited from upstream rather than introduced by us.
  Details are in holon-technologies/iroh#24. Happy to help with coordination.
- `get_many` has the same shape: an operator setting `get_many: Disabled`
  alongside `get: None` currently gets get-many silently allowed. Same fix covers
  it.
- Not addressed here, because it is outside this change: the pusher cannot
  observe a refusal at all. `execute_push_sink` calls `recv.stop(0)` and returns
  `Ok(Stats::default())` unconditionally, and the provider handles each stream in
  a detached task, so a small push reports success while the receiver drops
  every byte. That makes the newly-enforced default silent data loss for anyone
  who was relying on `BlobsProtocol::new(&store, None)` accepting pushes. Worth
  a follow-up on the remote API's error contract; say the word and I'll open one.
- Both new tests were confirmed to fail on unpatched `main`, for the right
  reason. 96 lib tests pass; `cargo clippy --all-targets --all-features` and
  `cargo fmt` clean on both commits.

## Change checklist

- [x] Tests if relevant.
- [x] All breaking changes documented.
- [ ] Self-review. <!-- reviewer: this branch was prepared with Claude Code and
      needs a human read before merge; I have not ticked the template's
      human-authored items on my own behalf. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)
