### PR TITLE
feat!: virtual blobs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -365,6 +365,15 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "block-buffer"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
@@ -670,6 +679,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -709,7 +719,7 @@ dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
- "digest",
+ "digest 0.11.3",
  "fiat-crypto",
  "rand_core 0.10.1",
  "rustc_version",
@@ -895,11 +905,22 @@ checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
 
 [[package]]
 name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer 0.10.4",
+ "crypto-common 0.1.7",
+ "subtle",
+]
+
+[[package]]
+name = "digest"
 version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
- "block-buffer",
+ "block-buffer 0.12.1",
  "crypto-common 0.2.2",
 ]
 
@@ -958,7 +979,7 @@ dependencies = [
  "ed25519",
  "rand_core 0.10.1",
  "serde",
- "sha2",
+ "sha2 0.11.0",
  "signature",
  "subtle",
  "zeroize",
@@ -1451,6 +1472,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
+
+[[package]]
 name = "http"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1855,11 +1894,13 @@ dependencies = [
 name = "iroh-blobs"
 version = "0.103.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "arrayvec",
  "async-compression",
  "atomic_refcell",
  "bao-tree",
+ "blake3",
  "bytes",
  "cfg_aliases",
  "chrono",
@@ -1871,6 +1912,7 @@ dependencies = [
  "genawaiter",
  "getrandom 0.4.2",
  "hex",
+ "hkdf",
  "iroh",
  "iroh-base",
  "iroh-io",
@@ -1895,6 +1937,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_test",
+ "sha2 0.10.9",
  "smallvec",
  "tempfile",
  "test-strategy",
@@ -3226,6 +3269,15 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
@@ -3705,13 +3757,24 @@ checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",
- "digest",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ getrandom = { version = "0.4", features = ["wasm_js"] }
 
 [dev-dependencies]
 clap = { version = "4.5.31", features = ["derive"] }
+aes-gcm = "0.10"
+hkdf = "0.12"
+sha2 = "0.10"
+blake3 = "1"
 hex = "0.4.3"
 iroh-test = "0.31.0"
 proptest = "1.6.0"

--- a/examples/encrypted_virtual_blob.rs
+++ b/examples/encrypted_virtual_blob.rs
@@ -40,7 +40,7 @@ use iroh_blobs::api::Store;
 use iroh_blobs::store::mem::MemStore;
 use iroh_blobs::store::virtual_blob::{DynVirtualSource, Provider, VirtualProviders};
 use iroh_blobs::store::IROH_BLOCK_SIZE;
-use iroh_blobs::{ALPN, BlobsProtocol, Hash};
+use iroh_blobs::{BlobsProtocol, Hash, ALPN};
 use sha2::Sha256;
 
 const PROVIDER_NAME: &str = "example-encrypted-blob-v1";
@@ -113,7 +113,11 @@ impl DemoCipher {
             0x01
         });
         self.aead
-            .encrypt_in_place(aes_gcm::Nonce::from_slice(&self.nonce(seq)), &[], &mut plaintext)
+            .encrypt_in_place(
+                aes_gcm::Nonce::from_slice(&self.nonce(seq)),
+                &[],
+                &mut plaintext,
+            )
             .expect("aes-gcm encryption cannot fail");
         plaintext
     }
@@ -176,7 +180,10 @@ fn decrypt_bytes(key: &BlobKey, ciphertext: &[u8]) -> Result<Vec<u8>> {
         }
         seq += 1;
         offset += take;
-        ensure!(offset < records.len(), "ciphertext ends without final record");
+        ensure!(
+            offset < records.len(),
+            "ciphertext ends without final record"
+        );
     }
     Ok(out)
 }
@@ -276,7 +283,8 @@ async fn main() -> Result<()> {
     //    buffer; for large media, stream the ciphertext through
     //    `store.blobs().build_outboard(..)` instead, which computes the
     //    (hash, outboard) pair incrementally without holding the bytes.
-    let outboard = bao_tree::io::outboard::PreOrderMemOutboard::create(&ciphertext, IROH_BLOCK_SIZE);
+    let outboard =
+        bao_tree::io::outboard::PreOrderMemOutboard::create(&ciphertext, IROH_BLOCK_SIZE);
     store
         .blobs()
         .add_virtual_with_outboard(
@@ -334,7 +342,6 @@ async fn main() -> Result<()> {
         "decrypted back to the original plaintext ({} bytes)",
         plaintext.len()
     );
-
 
     // Negative case: a virtual entry whose provider is not registered serves
     // as not-found to peers, even though the entry itself exists. (Node B's

--- a/examples/encrypted_virtual_blob.rs
+++ b/examples/encrypted_virtual_blob.rs
@@ -1,0 +1,367 @@
+//! Example: store plaintext locally, serve ciphertext on demand.
+//!
+//! A common shape for end-to-end encrypted storage: a device holds the
+//! plaintext (or the file it came from) and wants peers to fetch the
+//! *encrypted* form, which is what gets replicated. The
+//! ciphertext itself never needs to be stored on the serving device
+//! allowing local readers plaintext access.
+//!
+//! This example wires that up with virtual blobs:
+//!
+//! 1. Encrypt a plaintext into an RFC 8188 `aes128gcm` payload (a key pair of
+//!    salt + input keying material is generated per blob; the salt rides in
+//!    the payload header). The bytes of this ciphertext are never written to
+//!    disk - only its bao outboard and root hash are installed as a
+//!    *virtual* entry.
+//! 2. Register an on-demand provider that holds the key + plaintext and
+//!    re-encrypts only the records a peer asks for. `aes128gcm` records are
+//!    independently computable, so random access costs a couple of AES-GCM
+//!    operations per seek, regardless of blob size.
+//! 3. A second node fetches the ciphertext over iroh, bao-verifies it against
+//!    the ciphertext hash, stores it locally, and decrypts it.
+//!
+//! The demo codec below is a compact standalone implementation of RFC 8188's
+//! `aes128gcm` framing. Use a well-audited real-world codec in production.
+//!
+//! Run with `cargo run --example encrypted_virtual_blob`.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use aes_gcm::aead::{AeadInPlace, KeyInit};
+use aes_gcm::Aes128Gcm;
+use anyhow::{bail, ensure, Result};
+use bao_tree::io::mixed::ReadBytesAt;
+use hkdf::Hkdf;
+use iroh::address_lookup::MemoryLookup;
+use iroh::endpoint::presets;
+use iroh::protocol::Router;
+use iroh_blobs::api::Store;
+use iroh_blobs::store::mem::MemStore;
+use iroh_blobs::store::virtual_blob::{DynVirtualSource, Provider, VirtualProviders};
+use iroh_blobs::store::IROH_BLOCK_SIZE;
+use iroh_blobs::{ALPN, BlobsProtocol, Hash};
+use sha2::Sha256;
+
+const PROVIDER_NAME: &str = "example-encrypted-blob-v1";
+const RECORD_SIZE: u64 = 1024; // small on purpose: many records for the demo
+const RECORD_OVERHEAD: u64 = 17; // 1 delimiter octet + 16 octet GCM tag
+const PAYLOAD_MAX: u64 = RECORD_SIZE - RECORD_OVERHEAD;
+const HEADER_LEN: u64 = 21; // RFC 8188: salt (16) + rs (4) + idlen (1); no key id
+const SALT_LEN: usize = 16;
+
+/// A generated blob key: 32-octet input-keying material plus the per-blob
+/// salt that is transmitted in the plaintext header.
+///
+/// Never reuse (ikm, salt) across two different plaintexts: aes128gcm derives
+/// its CEKs and nonces from them, and GCM is catastrophic if a (CEK, nonce)
+/// pair repeats.
+#[derive(Clone)]
+struct BlobKey {
+    ikm: [u8; 32],
+    salt: [u8; SALT_LEN],
+}
+
+impl BlobKey {
+    fn generate() -> Self {
+        use rand::RngExt;
+        let mut ikm = [0u8; 32];
+        rand::rng().fill(&mut ikm);
+        let mut salt = [0u8; SALT_LEN];
+        rand::rng().fill(&mut salt);
+        Self { ikm, salt }
+    }
+}
+
+/// The per-blob cipher: CEK and nonce base are HKDF-SHA256 expansions of the
+/// input-keying material under the salt (RFC 8188 §2.2/§2.3).
+struct DemoCipher {
+    salt: [u8; SALT_LEN],
+    aead: Aes128Gcm,
+    nonce_base: [u8; 12],
+}
+
+impl DemoCipher {
+    fn new(ikm: &[u8], salt: &[u8; SALT_LEN]) -> Self {
+        let hk = Hkdf::<Sha256>::new(Some(salt), ikm);
+        let mut cek = [0u8; 16];
+        hk.expand(b"Content-Encoding: aes128gcm\x00", &mut cek)
+            .expect("cek length valid");
+        let mut nonce_base = [0u8; 12];
+        hk.expand(b"Content-Encoding: nonce\x00", &mut nonce_base)
+            .expect("nonce length valid");
+        Self {
+            salt: *salt,
+            aead: Aes128Gcm::new_from_slice(&cek).expect("cek length valid"),
+            nonce_base,
+        }
+    }
+
+    /// RFC 8188 §2.3: nonce = nonce_base XOR 96-bit record sequence number.
+    fn nonce(&self, seq: u64) -> [u8; 12] {
+        let mut n = self.nonce_base;
+        for (i, b) in seq.to_be_bytes().iter().enumerate() {
+            n[4 + i] ^= b;
+        }
+        n
+    }
+
+    fn encrypt_record(&self, seq: u64, last: bool, mut plaintext: Vec<u8>) -> Vec<u8> {
+        plaintext.push(if last {
+            0x02 // final record delimiter
+        } else {
+            0x01
+        });
+        self.aead
+            .encrypt_in_place(aes_gcm::Nonce::from_slice(&self.nonce(seq)), &[], &mut plaintext)
+            .expect("aes-gcm encryption cannot fail");
+        plaintext
+    }
+
+    fn decrypt_record(&self, seq: u64, record: &[u8]) -> Result<Vec<u8>> {
+        let mut buf = record.to_vec();
+        self.aead
+            .decrypt_in_place(aes_gcm::Nonce::from_slice(&self.nonce(seq)), &[], &mut buf)
+            .map_err(|e| anyhow::anyhow!("record auth failed: {e:?}"))?;
+        buf.pop();
+        Ok(buf)
+    }
+}
+
+/// Build the RFC 8188 body: header (salt, record size, empty key id) followed
+/// by all records. The final record carries delimiter 0x02 and may be short.
+fn encrypt_bytes(key: &BlobKey, plaintext: &[u8]) -> Vec<u8> {
+    let cipher = DemoCipher::new(&key.ikm, &key.salt);
+    let chunk_max = PAYLOAD_MAX as usize;
+    let mut out = Vec::with_capacity(plaintext.len() + 64);
+    out.extend_from_slice(&cipher.salt);
+    out.extend_from_slice(&RECORD_SIZE.to_be_bytes()[4..]); // rs: 32-bit BE
+    out.push(0); // idlen: no key id
+    if plaintext.is_empty() {
+        out.extend_from_slice(&cipher.encrypt_record(0, true, Vec::new()));
+        return out;
+    }
+    let n_records = plaintext.len().div_ceil(chunk_max);
+    for (seq, chunk) in plaintext.chunks(chunk_max).enumerate() {
+        out.extend_from_slice(&cipher.encrypt_record(
+            seq as u64,
+            seq == n_records - 1,
+            chunk.to_vec(),
+        ));
+    }
+    out
+}
+
+/// Decrypt a full RFC 8188 body: parse the header, then every record.
+fn decrypt_bytes(key: &BlobKey, ciphertext: &[u8]) -> Result<Vec<u8>> {
+    ensure!(
+        ciphertext.len() >= HEADER_LEN as usize,
+        "ciphertext shorter than header"
+    );
+    let rs = u32::from_be_bytes(ciphertext[16..20].try_into()?) as u64;
+    let idlen = ciphertext[20] as usize;
+    let cipher = DemoCipher::new(&key.ikm, &ciphertext[..SALT_LEN].try_into()?);
+    let records = &ciphertext[HEADER_LEN as usize + idlen..];
+    let mut out = Vec::new();
+    let mut seq = 0u64;
+    let mut offset = 0usize;
+    loop {
+        let take = (records.len() - offset).min(rs as usize);
+        ensure!(take > RECORD_OVERHEAD as usize, "truncated record");
+        let payload = cipher.decrypt_record(seq, &records[offset..offset + take])?;
+        out.extend_from_slice(&payload);
+        let last = offset + take == records.len();
+        if last {
+            break;
+        }
+        seq += 1;
+        offset += take;
+        ensure!(offset < records.len(), "ciphertext ends without final record");
+    }
+    Ok(out)
+}
+
+/// On-demand encryptor over stored plaintext.
+///
+/// The salt needed to reproduce wire-identical records travels along with the
+/// key and plaintext (it also appears in the header, so it does not need to
+/// be secret).
+struct OnDemandEncryptor {
+    key: BlobKey,
+    plain: bytes::Bytes,
+}
+
+impl OnDemandEncryptor {
+    fn ciphertext_len(&self) -> u64 {
+        HEADER_LEN + self.plain.len().div_ceil(PAYLOAD_MAX as usize) as u64 * RECORD_SIZE
+    }
+}
+
+impl ReadBytesAt for OnDemandEncryptor {
+    fn read_bytes_at(&self, offset: u64, size: usize) -> std::io::Result<bytes::Bytes> {
+        let end = (offset + size as u64).min(self.ciphertext_len());
+        let cipher = DemoCipher::new(&self.key.ikm, &self.key.salt);
+        let payload_max = PAYLOAD_MAX as usize;
+        let n_records = self.plain.len().div_ceil(payload_max).max(1);
+        let mut out = Vec::with_capacity(size);
+        let mut pos = offset;
+        if pos < HEADER_LEN {
+            let mut header = Vec::with_capacity(HEADER_LEN as usize);
+            header.extend_from_slice(&cipher.salt);
+            header.extend_from_slice(&RECORD_SIZE.to_be_bytes()[4..]); // rs: 32-bit BE
+            header.push(0); // idlen: no key id
+            let take = (HEADER_LEN - pos).min(end - pos) as usize;
+            out.extend_from_slice(&header[pos as usize..pos as usize + take]);
+            pos += take as u64;
+        }
+        while pos < end {
+            let rel = pos - HEADER_LEN;
+            let idx = (rel / RECORD_SIZE) as usize;
+            let within = (rel % RECORD_SIZE) as usize;
+            let payload_start = idx * payload_max;
+            let payload_end = (payload_start + payload_max).min(self.plain.len());
+            let chunk = self.plain[payload_start..payload_end].to_vec();
+            let record = cipher.encrypt_record(idx as u64, idx == n_records - 1, chunk);
+            let take = (record.len() - within).min((end - pos) as usize);
+            out.extend_from_slice(&record[within..within + take]);
+            pos += take as u64;
+        }
+        Ok(out.into())
+    }
+}
+
+/// Maps ciphertext hashes to the (key + plaintext) that materialize them.
+/// How an application finds the key for a hash is up to its own key store.
+#[derive(Default)]
+struct EncryptedProvider {
+    entries: HashMap<Hash, (BlobKey, bytes::Bytes)>,
+}
+
+impl Provider for EncryptedProvider {
+    fn reader_for(&self, hash: &Hash) -> Option<DynVirtualSource> {
+        let (key, plain) = self.entries.get(hash)?;
+        Some(Arc::new(OnDemandEncryptor {
+            key: key.clone(),
+            plain: plain.clone(),
+        }))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // -- The encrypt side (e.g. the device holding the original files). -----
+    let (store, virtuals) = MemStore::new_with_virtuals(Default::default());
+    let store = Store::from(store);
+
+    let key = BlobKey::generate();
+    // A demo plaintext spanning many 1024-byte records.
+    let plaintext: Vec<u8> = (0..100_000u32).map(|i| (i % 251) as u8).collect();
+
+    // 1. Encrypt once. The plaintext is stored as a normal local blob; the
+    //    ciphertext is not stored at all.
+    let ciphertext = encrypt_bytes(&key, &plaintext);
+    let p_hash = Hash::new(&plaintext);
+    let c_hash = Hash::new(&ciphertext);
+    println!(
+        "plaintext  {p_hash} ({} bytes, stored locally)",
+        plaintext.len()
+    );
+    println!(
+        "ciphertext {c_hash} ({} bytes, never stored)",
+        ciphertext.len()
+    );
+
+    // 2. Install the ciphertext as a virtual entry: bao outboard + size +
+    //    provider name. Demo-scale, so the outboard is computed from the
+    //    buffer; for large media, stream the ciphertext through
+    //    `store.blobs().build_outboard(..)` instead, which computes the
+    //    (hash, outboard) pair incrementally without holding the bytes.
+    let outboard = bao_tree::io::outboard::PreOrderMemOutboard::create(&ciphertext, IROH_BLOCK_SIZE);
+    store
+        .blobs()
+        .add_virtual_with_outboard(
+            c_hash,
+            ciphertext.len() as u64,
+            outboard.data.clone(),
+            PROVIDER_NAME,
+        )
+        .await?;
+    println!("installed virtual entry for {c_hash}");
+
+    // 3. Register the on-demand provider. Only the key + plaintext stay
+    //    local; the store can now serve C to any peer.
+    let provider = Arc::new(EncryptedProvider {
+        entries: HashMap::from([(c_hash, (key.clone(), plaintext.clone().into()))]),
+    });
+    virtuals.register(PROVIDER_NAME, provider)?;
+
+    // -- A second node (relay or backup target) fetches the ciphertext. -----
+    let (store_b, _virtuals_b) = MemStore::new_with_virtuals(Default::default());
+    let store_b = Store::from(store_b);
+    let lookup_a = MemoryLookup::new();
+    let lookup_b = MemoryLookup::new();
+    let endpoint_a = iroh::Endpoint::builder(presets::Minimal)
+        .relay_mode(iroh::RelayMode::Disabled)
+        .address_lookup(lookup_a.clone())
+        .bind()
+        .await?;
+    let endpoint_b = iroh::Endpoint::builder(presets::Minimal)
+        .relay_mode(iroh::RelayMode::Disabled)
+        .address_lookup(lookup_b.clone())
+        .bind()
+        .await?;
+    let blobs_a = BlobsProtocol::new(&store, None);
+    let router_a = Router::builder(endpoint_a.clone())
+        .accept(ALPN, blobs_a)
+        .spawn();
+    lookup_b.add_endpoint_info(endpoint_a.addr());
+
+    let conn = endpoint_b.connect(endpoint_a.addr(), ALPN).await?;
+    // The receiver stores C as a real, bao-verified blob - it can later
+    // re-serve or re-upload it without ever seeing P.
+    store_b.remote().fetch(conn, c_hash).await?;
+    let got_ct = store_b.get_bytes(c_hash).await?;
+    ensure!(
+        got_ct.as_ref() == ciphertext.as_slice(),
+        "receiver must see byte-identical ciphertext"
+    );
+    println!("fetched + bao-verified {c_hash} over iroh");
+
+    // 4. Decrypt on the peer: header salt + records -> plaintext.
+    let roundtripped = decrypt_bytes(&key, &got_ct)?;
+    ensure!(roundtripped == plaintext, "decrypted plaintext mismatch");
+    println!(
+        "decrypted back to the original plaintext ({} bytes)",
+        plaintext.len()
+    );
+
+
+    // Negative case: a virtual entry whose provider is not registered serves
+    // as not-found to peers, even though the entry itself exists. (Node B's
+    // fetched copy of the plaintext above is now stored content on B - it is
+    // served like any other stored blob.)
+    let orphan = encrypt_bytes(&BlobKey::generate(), b"nobody registered this");
+    let orphan_hash = Hash::new(&orphan);
+    let orphan_outboard =
+        bao_tree::io::outboard::PreOrderMemOutboard::create(&orphan, IROH_BLOCK_SIZE);
+    store
+        .blobs()
+        .add_virtual_with_outboard(
+            orphan_hash,
+            orphan.len() as u64,
+            orphan_outboard.data.clone(),
+            PROVIDER_NAME,
+        )
+        .await?;
+    let conn2 = endpoint_b.connect(endpoint_a.addr(), ALPN).await?;
+    match store_b.remote().fetch(conn2, orphan_hash).await {
+        Ok(_) => bail!("expected fetch to fail without a registered provider"),
+        Err(cause) => println!("no provider registered -> fetch fails as expected ({cause:?})"),
+    }
+
+    router_a.shutdown().await?;
+    endpoint_a.close().await;
+    endpoint_b.close().await;
+    println!("demo complete");
+    Ok(())
+}

--- a/src/api/blobs.rs
+++ b/src/api/blobs.rs
@@ -46,9 +46,10 @@ pub use super::proto::{
 };
 use super::{
     proto::{
-        BatchResponse, BlobStatusRequest, ClearProtectedRequest, CreateTempTagRequest,
-        ExportBaoRequest, ExportRangesItem, ImportBaoRequest, ImportByteStreamRequest,
-        ImportBytesRequest, ImportPathRequest, ListRequest, Scope,
+        AddVirtualRequest, AddVirtualWithOutboardRequest, BatchResponse, BlobStatusRequest,
+        BuildOutboardRequest, ClearProtectedRequest, CreateTempTagRequest, ExportBaoRequest,
+        ExportRangesItem, ImportBaoRequest, ImportByteStreamRequest, ImportBytesRequest,
+        ImportPathRequest, ListRequest, Scope,
     },
     remote::HashSeqChunk,
     tags::TagInfo,
@@ -311,6 +312,114 @@ impl Blobs {
         });
         AddProgress::new(self, stream)
     }
+
+    /// Build the BLAKE3 outboard for a stream of bytes without storing the data.
+    ///
+    /// The returned [`AddProgress`] reports the size and, on completion, a
+    /// [`TempTag`] protecting the resulting *virtual* entry — an entry that has
+    /// the outboard but no stored data. Associate it with a provider via
+    /// [`Self::add_virtual`], and register that provider in
+    /// [`crate::store::virtual_blob::VirtualProviders`] to serve it.
+    ///
+    /// This is the "build" half of the two-layer virtual blob API; the "add"
+    /// half attaches a random-access data source. Building is a sequential pass
+    /// (`Stream`), while serving is random-access (`ReadBytesAt`), so the two
+    /// take different source objects.
+    pub async fn build_outboard(
+        &self,
+        data: impl Stream<Item = io::Result<Bytes>> + Send + Sync + 'static,
+    ) -> AddProgress<'_> {
+        let inner = BuildOutboardRequest {
+            format: crate::BlobFormat::Raw,
+            scope: Scope::default(),
+        };
+        let client = self.client.clone();
+        let stream = Gen::new(|co| async move {
+            let (sender, mut receiver) = match client.bidi_streaming(inner, 32, 32).await {
+                Ok(x) => x,
+                Err(cause) => {
+                    co.yield_(AddProgressItem::Error(cause.into())).await;
+                    return;
+                }
+            };
+            let recv = async {
+                loop {
+                    match receiver.recv().await {
+                        Ok(Some(item)) => co.yield_(item).await,
+                        Err(cause) => {
+                            co.yield_(AddProgressItem::Error(cause.into())).await;
+                            break;
+                        }
+                        Ok(None) => break,
+                    }
+                }
+            };
+            let send = async {
+                tokio::pin!(data);
+                while let Some(item) = data.next().await {
+                    sender.send(ImportByteStreamUpdate::Bytes(item?)).await?;
+                }
+                sender.send(ImportByteStreamUpdate::Done).await?;
+                n0_error::Ok(())
+            };
+            let _ = tokio::join!(send, recv);
+        });
+        AddProgress::new(self, stream)
+    }
+
+    /// Associate a virtual entry with the name of the provider that serves it.
+    ///
+    /// This is the "add" half of the two-layer virtual blob API; the "build"
+    /// half is [`Self::build_outboard`]. The provider name is stored durably
+    /// with the entry. Serving the entry looks up a live provider registered
+    /// under this name (see
+    /// [`crate::store::virtual_blob::VirtualProviders`]) and fails with
+    /// `NotFound` if none is registered (or if the provider does not serve the
+    /// hash).
+    ///
+    /// Returns an error if there is no virtual entry for `hash`.
+    pub async fn add_virtual(
+        &self,
+        hash: impl Into<Hash>,
+        provider: impl Into<String>,
+    ) -> super::RequestResult<()> {
+        let msg = AddVirtualRequest {
+            hash: hash.into(),
+            provider: provider.into(),
+        };
+        self.client.rpc(msg).await??;
+        Ok(())
+}
+
+/// Create a virtual entry from a caller-supplied bao outboard.
+///
+/// This is the getter-side counterpart of [`Self::fetch_bao_to`]: collect the
+/// verified parent items into the standard pre-order outboard serialization
+/// and install them here together with the expected size. The entry behaves
+/// exactly like one created via [`Self::build_outboard`]; name a provider via
+/// `provider` (the same name later passed to [`crate::store::virtual_blob::VirtualProviders::register`])
+/// to serve it.
+///
+/// The `outboard` must be the standard pre-order serialization for `size`
+/// (empty when the blob fits in a single chunk); its length is validated
+/// against `size`. An entry that already exists as stored (`Complete`) or
+/// partial data is rejected; an existing virtual or missing entry is set.
+pub async fn add_virtual_with_outboard(
+        &self,
+        hash: impl Into<Hash>,
+        size: u64,
+        outboard: impl Into<Bytes>,
+        provider: impl Into<String>,
+) -> super::RequestResult<()> {
+        let msg = AddVirtualWithOutboardRequest {
+            hash: hash.into(),
+            size,
+            outboard: outboard.into(),
+            provider: provider.into(),
+        };
+        self.client.rpc(msg).await??;
+        Ok(())
+}
 
     pub fn export_ranges(
         &self,

--- a/src/api/blobs.rs
+++ b/src/api/blobs.rs
@@ -314,17 +314,6 @@ impl Blobs {
     }
 
     /// Build the BLAKE3 outboard for a stream of bytes without storing the data.
-    ///
-    /// The returned [`AddProgress`] reports the size and, on completion, a
-    /// [`TempTag`] protecting the resulting *virtual* entry — an entry that has
-    /// the outboard but no stored data. Associate it with a provider via
-    /// [`Self::add_virtual`], and register that provider in
-    /// [`crate::store::virtual_blob::VirtualProviders`] to serve it.
-    ///
-    /// This is the "build" half of the two-layer virtual blob API; the "add"
-    /// half attaches a random-access data source. Building is a sequential pass
-    /// (`Stream`), while serving is random-access (`ReadBytesAt`), so the two
-    /// take different source objects.
     pub async fn build_outboard(
         &self,
         data: impl Stream<Item = io::Result<Bytes>> + Send + Sync + 'static,
@@ -389,28 +378,28 @@ impl Blobs {
         };
         self.client.rpc(msg).await??;
         Ok(())
-}
+    }
 
-/// Create a virtual entry from a caller-supplied bao outboard.
-///
-/// This is the getter-side counterpart of [`Self::fetch_bao_to`]: collect the
-/// verified parent items into the standard pre-order outboard serialization
-/// and install them here together with the expected size. The entry behaves
-/// exactly like one created via [`Self::build_outboard`]; name a provider via
-/// `provider` (the same name later passed to [`crate::store::virtual_blob::VirtualProviders::register`])
-/// to serve it.
-///
-/// The `outboard` must be the standard pre-order serialization for `size`
-/// (empty when the blob fits in a single chunk); its length is validated
-/// against `size`. An entry that already exists as stored (`Complete`) or
-/// partial data is rejected; an existing virtual or missing entry is set.
-pub async fn add_virtual_with_outboard(
+    /// Create a virtual entry from a caller-supplied bao outboard.
+    ///
+    /// This is the getter-side counterpart of [`Self::fetch_bao_to`]: collect the
+    /// verified parent items into the standard pre-order outboard serialization
+    /// and install them here together with the expected size. The entry behaves
+    /// exactly like one created via [`Self::build_outboard`]; name a provider via
+    /// `provider` (the same name later passed to [`crate::store::virtual_blob::VirtualProviders::register`])
+    /// to serve it.
+    ///
+    /// The `outboard` must be the standard pre-order serialization for `size`
+    /// (empty when the blob fits in a single chunk); its length is validated
+    /// against `size`. An entry that already exists as stored (`Complete`) or
+    /// partial data is rejected; an existing virtual or missing entry is set.
+    pub async fn add_virtual_with_outboard(
         &self,
         hash: impl Into<Hash>,
         size: u64,
         outboard: impl Into<Bytes>,
         provider: impl Into<String>,
-) -> super::RequestResult<()> {
+    ) -> super::RequestResult<()> {
         let msg = AddVirtualWithOutboardRequest {
             hash: hash.into(),
             size,
@@ -419,7 +408,7 @@ pub async fn add_virtual_with_outboard(
         };
         self.client.rpc(msg).await??;
         Ok(())
-}
+    }
 
     pub fn export_ranges(
         &self,

--- a/src/api/proto.rs
+++ b/src/api/proto.rs
@@ -110,6 +110,29 @@ pub enum Request {
     ImportBytes(ImportBytesRequest),
     #[rpc(rx = mpsc::Receiver<ImportByteStreamUpdate>, tx = mpsc::Sender<AddProgressItem>)]
     ImportByteStream(ImportByteStreamRequest),
+    /// Build the BLAKE3 outboard for a stream of bytes without storing the data.
+    ///
+    /// The bytes are streamed in via the `rx` channel; the resulting hash and
+    /// size are reported via `AddProgressItem` (with the data discarded). The
+    /// outboard is stored in the store as a *virtual* entry, which can later be
+    /// served by associating it with a provider via `AddVirtual` (see
+    /// [`crate::store::virtual_blob::VirtualProviders`]).
+    #[rpc(rx = mpsc::Receiver<ImportByteStreamUpdate>, tx = mpsc::Sender<AddProgressItem>)]
+    BuildOutboard(BuildOutboardRequest),
+    /// Associate a virtual entry with the name of the provider that serves it.
+    ///
+    /// The entry must already exist as a virtual entry (its outboard must have
+    /// been computed via `BuildOutboard`). The provider name is stored durably
+    /// with the entry; serving the entry looks up a live provider registered
+    /// under this name (see [`crate::store::virtual_blob::VirtualProviders`])
+    /// and fails with `NotFound` if none is registered.
+    #[rpc(tx = oneshot::Sender<super::Result<()>>)]
+    AddVirtual(AddVirtualRequest),
+    /// Create a virtual entry from a caller-supplied bao outboard.
+    ///
+    /// See [`AddVirtualWithOutboardRequest`] for details.
+    #[rpc(tx = oneshot::Sender<super::Result<()>>)]
+    AddVirtualWithOutboard(AddVirtualWithOutboardRequest),
     #[rpc(tx = mpsc::Sender<AddProgressItem>)]
     ImportPath(ImportPathRequest),
     #[rpc(tx = mpsc::Sender<ExportProgressItem>)]
@@ -252,10 +275,52 @@ pub struct ImportByteStreamRequest {
     pub scope: Scope,
 }
 
+/// Request to build an outboard from a stream of bytes without storing the data.
+///
+/// The bytes are streamed in as [`ImportByteStreamUpdate`] on the request's
+/// `rx` channel; progress and the final result are reported as
+/// [`AddProgressItem`] on the `tx` channel.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct BuildOutboardRequest {
+    pub format: BlobFormat,
+    pub scope: Scope,
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub enum ImportByteStreamUpdate {
     Bytes(Bytes),
     Done,
+}
+
+/// Associate a virtual entry with the name of the provider that serves it.
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AddVirtualRequest {
+    /// The hash of the virtual entry.
+    pub hash: Hash,
+    /// The name of the provider that serves this entry's data.
+    pub provider: String,
+}
+
+/// Create a virtual entry from a caller-supplied bao outboard.
+///
+/// This is the getter-side counterpart to fetching a blob without importing
+/// it ([`crate::api::blobs::Blobs::fetch_bao_to`]): the verified parent items
+/// assemble into the standard pre-order outboard serialization used by this
+/// crate, and are installed here as a virtual entry. The data is not stored;
+/// serving requires associating a provider via `AddVirtual` and registering
+/// it in [`crate::store::virtual_blob::VirtualProviders`].
+#[derive(Debug, Serialize, Deserialize)]
+pub struct AddVirtualWithOutboardRequest {
+    /// The hash of the blob. Must be the root of `outboard`.
+    pub hash: Hash,
+    /// The size of the (not stored) blob data in bytes.
+    pub size: u64,
+    /// The bao outboard in the standard pre-order serialization, without the
+    /// root node (the same bytes `build_outboard` stores). Empty when the blob
+    /// fits in a single chunk.
+    pub outboard: Bytes,
+    /// The name of the provider that serves this entry's data.
+    pub provider: String,
 }
 
 /// Options for a list operation.

--- a/src/api/proto.rs
+++ b/src/api/proto.rs
@@ -110,27 +110,10 @@ pub enum Request {
     ImportBytes(ImportBytesRequest),
     #[rpc(rx = mpsc::Receiver<ImportByteStreamUpdate>, tx = mpsc::Sender<AddProgressItem>)]
     ImportByteStream(ImportByteStreamRequest),
-    /// Build the BLAKE3 outboard for a stream of bytes without storing the data.
-    ///
-    /// The bytes are streamed in via the `rx` channel; the resulting hash and
-    /// size are reported via `AddProgressItem` (with the data discarded). The
-    /// outboard is stored in the store as a *virtual* entry, which can later be
-    /// served by associating it with a provider via `AddVirtual` (see
-    /// [`crate::store::virtual_blob::VirtualProviders`]).
     #[rpc(rx = mpsc::Receiver<ImportByteStreamUpdate>, tx = mpsc::Sender<AddProgressItem>)]
     BuildOutboard(BuildOutboardRequest),
-    /// Associate a virtual entry with the name of the provider that serves it.
-    ///
-    /// The entry must already exist as a virtual entry (its outboard must have
-    /// been computed via `BuildOutboard`). The provider name is stored durably
-    /// with the entry; serving the entry looks up a live provider registered
-    /// under this name (see [`crate::store::virtual_blob::VirtualProviders`])
-    /// and fails with `NotFound` if none is registered.
     #[rpc(tx = oneshot::Sender<super::Result<()>>)]
     AddVirtual(AddVirtualRequest),
-    /// Create a virtual entry from a caller-supplied bao outboard.
-    ///
-    /// See [`AddVirtualWithOutboardRequest`] for details.
     #[rpc(tx = oneshot::Sender<super::Result<()>>)]
     AddVirtualWithOutboard(AddVirtualWithOutboardRequest),
     #[rpc(tx = mpsc::Sender<AddProgressItem>)]
@@ -277,9 +260,11 @@ pub struct ImportByteStreamRequest {
 
 /// Request to build an outboard from a stream of bytes without storing the data.
 ///
-/// The bytes are streamed in as [`ImportByteStreamUpdate`] on the request's
-/// `rx` channel; progress and the final result are reported as
-/// [`AddProgressItem`] on the `tx` channel.
+/// The bytes are streamed in via the `rx` channel; the resulting hash and
+/// size are reported via [`AddProgressItem`] (with the data discarded). The
+/// outboard is stored in the store as a *virtual* entry, which can later be
+/// served by associating it with a provider via `AddVirtual` (see
+/// [`crate::store::virtual_blob::VirtualProviders`]).
 #[derive(Debug, Serialize, Deserialize)]
 pub struct BuildOutboardRequest {
     pub format: BlobFormat,
@@ -293,6 +278,12 @@ pub enum ImportByteStreamUpdate {
 }
 
 /// Associate a virtual entry with the name of the provider that serves it.
+///
+/// The entry must already exist as a virtual entry (its outboard must have
+/// been computed via `BuildOutboard`). The provider name is stored durably
+/// with the entry; serving the entry looks up a live provider registered
+/// under this name (see [`crate::store::virtual_blob::VirtualProviders`])
+/// and fails with `NotFound` if none is registered.
 #[derive(Debug, Serialize, Deserialize)]
 pub struct AddVirtualRequest {
     /// The hash of the virtual entry.

--- a/src/api/remote.rs
+++ b/src/api/remote.rs
@@ -539,7 +539,7 @@ impl Remote {
         Ok(stats)
     }
 
-    /// Download a single blob's verified [`BaoContentItem`]s into a
+    /// Download (a byte range of) a single blob's verified [`BaoContentItem`]s into a
     /// caller-provided channel, without importing them into any store.
     ///
     /// This is the getter-side half of the virtual blob API: the caller owns
@@ -548,19 +548,41 @@ impl Remote {
     /// the [`BaoContentItem::Leaf`] data through a transform, and register a
     /// virtual entry. The blob is not written to the local store.
     ///
+    /// `ranges` limits the transfer to the given chunk (byte) ranges of the
+    /// blob, e.g. a single window for a seek, or a suffix for a resuming
+    /// download. Only chunks overlapping the requested ranges are delivered,
+    /// but every leaf is verified against `hash` as usual, so a resumed
+    /// download trusts the same root as an uninterrupted one. Use
+    /// [`ChunkRanges::all`] for the whole blob.
+    ///
+    /// ## Resume caveat
+    ///
+    /// Unlike store-importing transfers ([`Self::fetch`]), this primitive
+    /// keeps no receiver-side state: a cancelled call retains nothing, and
+    /// resuming is the caller's job. Track transform-space progress (the
+    /// transform's own record or byte watermark), persist whatever durable
+    /// state the transform needs, then call this again with the missing
+    /// ranges. This asymmetry is inherent: the transferred representation
+    /// (this blob's chunk space) and the caller's imported representation
+    /// generally have different framing - different chunk boundaries and
+    /// possibly different lengths - so a store bitfield of the imported
+    /// representation cannot be translated into request ranges of the
+    /// transferred one.
+    ///
     /// `hash` identifies a single raw blob (collections / hash sequences are
     /// not supported here; use [`Self::fetch`] for those).
     ///
-    /// Returns once the blob has been fully streamed into `item_tx`. The caller
-    /// should drain the receiver to completion; `item_tx` is dropped when the
-    /// blob is done.
+    /// Returns once the requested ranges have been streamed into `item_tx`.
+    /// The caller should drain the receiver to completion; `item_tx` is
+    /// dropped when the blob is done.
     pub async fn fetch_bao_to(
         &self,
         sp: impl GetStreamPair,
         hash: Hash,
+        ranges: impl Into<bao_tree::ChunkRanges>,
         item_tx: irpc::channel::mpsc::Sender<BaoContentItem>,
     ) -> GetResult<Stats> {
-        let request = GetRequest::blob(hash);
+        let request = GetRequest::blob_ranges(hash, ranges.into());
         self.execute_get_bao_to(sp, request, item_tx).await
     }
 

--- a/src/api/remote.rs
+++ b/src/api/remote.rs
@@ -20,7 +20,7 @@ use n0_future::{io, Stream, StreamExt};
 use ref_cast::RefCast;
 use tracing::{debug, trace};
 
-use super::blobs::{Bitfield, ExportBaoOptions};
+use super::blobs::{Bitfield, ExportBaoOptions, ImportBaoHandle};
 use crate::{
     api::{
         self,
@@ -42,7 +42,7 @@ use crate::{
     provider::events::{ClientResult, ProgressError},
     store::IROH_BLOCK_SIZE,
     util::{
-        sink::{Sink, TokioMpscSenderSink},
+        sink::{Drain, Sink, TokioMpscSenderSink},
         RecvStream, SendStream,
     },
     Hash, HashAndFormat,
@@ -539,6 +539,31 @@ impl Remote {
         Ok(stats)
     }
 
+    /// Download a single blob's verified [`BaoContentItem`]s into a
+    /// caller-provided channel, without importing them into any store.
+    ///
+    /// This is the getter-side half of the virtual blob API: the caller owns
+    /// the receiver side of `item_tx` and processes the verified items itself
+    /// — e.g. keep the [`BaoContentItem::Parent`] nodes as an outboard, feed
+    /// the [`BaoContentItem::Leaf`] data through a transform, and register a
+    /// virtual entry. The blob is not written to the local store.
+    ///
+    /// `hash` identifies a single raw blob (collections / hash sequences are
+    /// not supported here; use [`Self::fetch`] for those).
+    ///
+    /// Returns once the blob has been fully streamed into `item_tx`. The caller
+    /// should drain the receiver to completion; `item_tx` is dropped when the
+    /// blob is done.
+    pub async fn fetch_bao_to(
+        &self,
+        sp: impl GetStreamPair,
+        hash: Hash,
+        item_tx: irpc::channel::mpsc::Sender<BaoContentItem>,
+    ) -> GetResult<Stats> {
+        let request = GetRequest::blob(hash);
+        self.execute_get_bao_to(sp, request, item_tx).await
+    }
+
     pub fn observe(
         &self,
         conn: Connection,
@@ -743,6 +768,62 @@ impl Remote {
         Ok(stats)
     }
 
+    /// Like [`Self::execute_get_sink`] but forwards each blob's verified
+    /// [`BaoContentItem`]s into a caller-provided channel instead of importing
+    /// them into the store.
+    ///
+    /// Only a single raw blob is supported; if the response contains children
+    /// (a hash sequence), an error is returned.
+    pub(crate) async fn execute_get_bao_to(
+        &self,
+        conn: impl GetStreamPair,
+        request: GetRequest,
+        item_tx: irpc::channel::mpsc::Sender<BaoContentItem>,
+    ) -> GetResult<Stats> {
+        let root = request.hash;
+        let conn = conn.open_stream_pair().await.map_err(|e| {
+            e!(
+                GetError::LocalFailure,
+                n0_error::anyerr!("failed to open stream pair: {e}")
+            )
+        })?;
+        let connected =
+            AtConnected::new(conn.t0, conn.recv, conn.send, request, Default::default());
+        trace!("Getting header (bao_to)");
+        let at_closing = match connected
+            .next()
+            .await
+            .map_err(|e| e!(GetError::ConnectedNext, e))?
+        {
+            ConnectedNext::StartRoot(at_start_root) => {
+                let header = at_start_root.next();
+                let end = get_blob_ranges_to(header, root, Drain, item_tx).await?;
+                match end.next() {
+                    EndBlobNext::MoreChildren(_) => {
+                        return Err(e!(
+                            GetError::BadRequest,
+                            n0_error::anyerr!("fetch_bao_to does not support hash sequences")
+                        ));
+                    }
+                    EndBlobNext::Closing(at_closing) => at_closing,
+                }
+            }
+            ConnectedNext::StartChild(_) => {
+                return Err(e!(
+                    GetError::BadRequest,
+                    n0_error::anyerr!("fetch_bao_to does not support hash sequences")
+                ));
+            }
+            ConnectedNext::Closing(at_closing) => at_closing,
+        };
+        let stats = at_closing
+            .next()
+            .await
+            .map_err(|e| e!(GetError::AtClosingNext, e))?;
+        trace!(?stats, "get bao_to done");
+        Ok(stats)
+    }
+
     pub fn execute_get_many(&self, conn: Connection, request: GetManyRequest) -> GetProgress {
         let (tx, rx) = tokio::sync::mpsc::channel(64);
         let tx2 = tx.clone();
@@ -881,13 +962,46 @@ fn get_buffer_size(size: NonZeroU64) -> usize {
     (size.get() / (IROH_BLOCK_SIZE.bytes() as u64) + 2).min(64) as usize
 }
 
+/// Forward verified [`BaoContentItem`]s from a blob content stream to a channel,
+/// reporting per-item payload byte progress.
+///
+/// This is the shared loop used by both the store-import path
+/// ([`get_blob_ranges_impl`]) and the sink-only path ([`get_blob_ranges_to`]).
+async fn forward_blob_content<R: RecvStream>(
+    mut content: crate::get::fsm::AtBlobContent<R>,
+    mut progress: impl Sink<u64, Error = irpc::channel::SendError>,
+    item_tx: irpc::channel::mpsc::Sender<BaoContentItem>,
+) -> GetResult<AtEndBlob<R>> {
+    let end = loop {
+        match content.next().await {
+            BlobContentNext::More((next, res)) => {
+                let item = res.map_err(|e| e!(GetError::Decode, e))?;
+                progress
+                    .send(next.stats().payload_bytes_read)
+                    .await
+                    .map_err(|e| e!(GetError::LocalFailure, e.into()))?;
+                item_tx
+                    .send(item)
+                    .await
+                    .map_err(|e| e!(GetError::IrpcSend, e))?;
+                content = next;
+            }
+            BlobContentNext::Done(end) => {
+                drop(item_tx);
+                break end;
+            }
+        }
+    };
+    Ok(end)
+}
+
 async fn get_blob_ranges_impl<R: RecvStream>(
     header: AtBlobHeader<R>,
     hash: Hash,
     store: &Store,
-    mut progress: impl Sink<u64, Error = irpc::channel::SendError>,
+    progress: impl Sink<u64, Error = irpc::channel::SendError>,
 ) -> GetResult<AtEndBlob<R>> {
-    let (mut content, size) = header
+    let (content, size) = header
         .next()
         .await
         .map_err(|e| e!(GetError::AtBlobHeaderNext, e))?;
@@ -908,31 +1022,10 @@ async fn get_blob_ranges_impl<R: RecvStream>(
         .import_bao(hash, size, buffer_size)
         .await
         .map_err(|e| e!(GetError::LocalFailure, e.into()))?;
-    let write = async move {
-        GetResult::Ok(loop {
-            match content.next().await {
-                BlobContentNext::More((next, res)) => {
-                    let item = res.map_err(|e| e!(GetError::Decode, e))?;
-                    progress
-                        .send(next.stats().payload_bytes_read)
-                        .await
-                        .map_err(|e| e!(GetError::LocalFailure, e.into()))?;
-                    handle
-                        .tx
-                        .send(item)
-                        .await
-                        .map_err(|e| e!(GetError::IrpcSend, e))?;
-                    content = next;
-                }
-                BlobContentNext::Done(end) => {
-                    drop(handle.tx);
-                    break end;
-                }
-            }
-        })
-    };
+    let ImportBaoHandle { tx, rx } = handle;
+    let write = forward_blob_content(content, progress, tx);
     let complete = async move {
-        handle.rx.await.map_err(|e| {
+        rx.await.map_err(|e| {
             e!(
                 GetError::LocalFailure,
                 n0_error::anyerr!("error reading from import stream: {e}")
@@ -941,6 +1034,37 @@ async fn get_blob_ranges_impl<R: RecvStream>(
     };
     let (_, end) = tokio::try_join!(complete, write)?;
     Ok(end)
+}
+
+/// Like [`get_blob_ranges_impl`] but forwards verified [`BaoContentItem`]s into
+/// a caller-provided channel instead of importing them into a store.
+///
+/// This is the getter-side half of the virtual blob API: a caller can download
+/// a blob's verified items (leaves = data, parents = outboard) and process them
+/// itself — e.g. keep the parents as an outboard, transform the leaves, and
+/// register a virtual entry — without writing the blob into any store.
+async fn get_blob_ranges_to<R: RecvStream>(
+    header: AtBlobHeader<R>,
+    hash: Hash,
+    progress: impl Sink<u64, Error = irpc::channel::SendError>,
+    item_tx: irpc::channel::mpsc::Sender<BaoContentItem>,
+) -> GetResult<AtEndBlob<R>> {
+    let (content, size) = header
+        .next()
+        .await
+        .map_err(|e| e!(GetError::AtBlobHeaderNext, e))?;
+    let Some(_size) = NonZeroU64::new(size) else {
+        return if hash == Hash::EMPTY {
+            let end = content.drain().await.map_err(|e| e!(GetError::Decode, e))?;
+            Ok(end)
+        } else {
+            Err(e!(
+                GetError::Decode,
+                DecodeError::leaf_hash_mismatch(ChunkNum(0))
+            ))
+        };
+    };
+    forward_blob_content(content, progress, item_tx).await
 }
 
 #[derive(Debug)]

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -93,13 +93,13 @@ use entity_manager::{EntityManagerState, SpawnArg};
 use entry_state::{DataLocation, OutboardLocation};
 use import::{ImportEntry, ImportSource};
 use irpc::{channel::mpsc, RpcMessage};
-use meta::list_blobs;
+use meta::{list_blobs, raw_outboard_size};
 use n0_error::{Result, StdResultExt};
 use n0_future::{future::yield_now, io};
 use nested_enum_utils::enum_conversions;
 use range_collections::range_set::RangeSetRange;
 use tokio::task::{JoinError, JoinSet};
-use tracing::{error, instrument, trace};
+use tracing::{error, instrument, trace, Span};
 
 use crate::{
     api::{
@@ -107,7 +107,8 @@ use crate::{
             self, bitfield::is_validated, BatchMsg, BatchResponse, Bitfield, Command,
             CreateTempTagMsg, ExportBaoMsg, ExportBaoRequest, ExportPathMsg, ExportPathRequest,
             ExportRangesItem, ExportRangesMsg, ExportRangesRequest, HashSpecific, ImportBaoMsg,
-            ImportBaoRequest, ObserveMsg, Scope,
+            ImportBaoRequest, ObserveMsg, Scope, AddVirtualWithOutboardMsg,
+            AddVirtualWithOutboardRequest,
         },
         ApiClient,
     },
@@ -122,6 +123,7 @@ use crate::{
         },
         gc::run_gc,
         util::{BaoTreeSender, FixedSize, MemOrFile, ValueOrPoisioned},
+        virtual_blob::{DynReadBytesAt, VirtualProviders},
         IROH_BLOCK_SIZE,
     },
     util::{
@@ -139,7 +141,7 @@ mod meta;
 pub mod options;
 pub(crate) mod util;
 use entry_state::EntryState;
-use import::{import_byte_stream, import_bytes, import_path, ImportEntryMsg};
+use import::{build_outboard, import_byte_stream, import_bytes, import_path, ImportEntryMsg};
 use options::Options;
 use tracing::Instrument;
 
@@ -149,7 +151,7 @@ use crate::{
         blobs::{AddProgressItem, ExportMode, ExportProgressItem},
         Store,
     },
-    HashAndFormat,
+    BlobFormat, HashAndFormat,
 };
 
 /// Maximum number of external paths we track per blob.
@@ -174,7 +176,22 @@ fn temp_name() -> String {
 pub(crate) enum InternalCommand {
     Dump(meta::Dump),
     FinishImport(ImportEntryMsg),
+    FinishBuildOutboard(FinishBuildOutboardMsg),
     ClearScope(ClearScope),
+}
+
+/// Internal command carrying the result of a `BuildOutboard` operation: the
+/// computed outboard (in memory or as a temp file) and size for a virtual
+/// entry, plus the channels to finish registration.
+#[derive(Debug)]
+pub(crate) struct FinishBuildOutboardMsg {
+    pub hash: Hash,
+    pub scope: Scope,
+    pub format: BlobFormat,
+    pub outboard: MemOrFile<Bytes, PathBuf>,
+    pub size: u64,
+    pub tx: mpsc::Sender<AddProgressItem>,
+    pub span: tracing::Span,
 }
 
 #[derive(Debug)]
@@ -187,6 +204,7 @@ impl InternalCommand {
         match self {
             Self::Dump(_) => tracing::Span::current(),
             Self::ClearScope(_) => tracing::Span::current(),
+            Self::FinishBuildOutboard(cmd) => cmd.span.clone(),
             Self::FinishImport(cmd) => cmd
                 .parent_span_opt()
                 .cloned()
@@ -206,6 +224,8 @@ struct TaskContext {
     pub internal_cmd_tx: tokio::sync::mpsc::Sender<InternalCommand>,
     /// Handle to protect files from deletion.
     pub protect: ProtectHandle,
+    /// Live providers for virtual blobs, keyed by provider name.
+    pub virtuals: VirtualProviders,
 }
 
 impl TaskContext {
@@ -355,6 +375,7 @@ impl SyncEntityApi for HashContext {
     fn current_size(&self) -> io::Result<u64> {
         match self.state.borrow().deref() {
             BaoFileStorage::Complete(mem) => Ok(mem.size()),
+            BaoFileStorage::Virtual(mem) => Ok(mem.size()),
             BaoFileStorage::PartialMem(mem) => Ok(mem.current_size()),
             BaoFileStorage::Partial(file) => file.current_size(),
             BaoFileStorage::Poisoned => Err(io::Error::other("poisoned storage")),
@@ -368,6 +389,7 @@ impl SyncEntityApi for HashContext {
     fn bitfield(&self) -> io::Result<Bitfield> {
         match self.state.borrow().deref() {
             BaoFileStorage::Complete(mem) => Ok(mem.bitfield()),
+            BaoFileStorage::Virtual(mem) => Ok(mem.bitfield()),
             BaoFileStorage::PartialMem(mem) => Ok(mem.bitfield().clone()),
             BaoFileStorage::Partial(file) => Ok(file.bitfield().clone()),
             BaoFileStorage::Poisoned => Err(io::Error::other("poisoned storage")),
@@ -539,6 +561,18 @@ impl Actor {
                 trace!("{cmd:?}");
                 self.spawn(import_byte_stream(cmd, self.context()));
             }
+            Command::BuildOutboard(cmd) => {
+                trace!("{cmd:?}");
+                self.spawn(build_outboard(cmd, self.context()));
+            }
+            Command::AddVirtual(cmd) => {
+                trace!("{cmd:?}");
+                self.db().send(cmd.into()).await.ok();
+            }
+            Command::AddVirtualWithOutboard(cmd) => {
+                trace!("{cmd:?}");
+                self.spawn(add_virtual_with_outboard(cmd, self.context()));
+            }
             Command::ImportPath(cmd) => {
                 trace!("{cmd:?}");
                 self.spawn(import_path(cmd, self.context()));
@@ -596,6 +630,28 @@ impl Actor {
                     (tt, cmd).spawn(&mut self.handles, &mut self.tasks).await;
                 }
             }
+            InternalCommand::FinishBuildOutboard(cmd) => {
+                trace!("{cmd:?}");
+                let mut tt = self.temp_tags.create(
+                    cmd.scope,
+                    HashAndFormat {
+                        hash: cmd.hash,
+                        format: cmd.format,
+                    },
+                );
+                let ctx = self.context.clone();
+                let res = finish_build_outboard_impl(&ctx, cmd.hash, cmd.outboard, cmd.size).await;
+                let item = match res {
+                    Ok(()) => {
+                        if cmd.tx.is_rpc() {
+                            tt.leak();
+                        }
+                        AddProgressItem::Done(tt)
+                    }
+                    Err(cause) => AddProgressItem::Error(cause),
+                };
+                cmd.tx.send(item).await.ok();
+            }
         }
     }
 
@@ -639,7 +695,7 @@ impl Actor {
         fs_commands_rx: tokio::sync::mpsc::Receiver<InternalCommand>,
         fs_commands_tx: tokio::sync::mpsc::Sender<InternalCommand>,
         options: Arc<Options>,
-    ) -> Result<Self> {
+    ) -> Result<(Self, VirtualProviders)> {
         trace!(
             "creating data directory: {}",
             options.path.data_path.display()
@@ -658,23 +714,28 @@ impl Actor {
         let (db_send, db_recv) = tokio::sync::mpsc::channel(100);
         let (protect, ds) = delete_set::pair(Arc::new(options.path.clone()));
         let db_actor = meta::Actor::new(db_path, db_recv, ds, options.batch.clone())?;
+        let virtuals = VirtualProviders::new();
         let slot_context = Arc::new(TaskContext {
             options: options.clone(),
             db: meta::Db::new(db_send),
             internal_cmd_tx: fs_commands_tx,
             protect,
+            virtuals: virtuals.clone(),
         });
         rt.spawn(db_actor.run());
-        Ok(Self {
-            context: slot_context.clone(),
-            cmd_rx,
-            fs_cmd_rx: fs_commands_rx,
-            tasks: JoinSet::new(),
-            handles: EntityManagerState::new(slot_context, 1024, 32, 32, 2),
-            temp_tags: Default::default(),
-            idle_waiters: Vec::new(),
-            _rt: rt,
-        })
+        Ok((
+            Self {
+                context: slot_context.clone(),
+                cmd_rx,
+                fs_cmd_rx: fs_commands_rx,
+                tasks: JoinSet::new(),
+                handles: EntityManagerState::new(slot_context, 1024, 32, 32, 2),
+                temp_tags: Default::default(),
+                idle_waiters: Vec::new(),
+                _rt: rt,
+            },
+            virtuals,
+        ))
     }
 }
 
@@ -948,6 +1009,61 @@ impl EntityApi for HashContext {
     async fn export_bao(&self, mut cmd: ExportBaoMsg) {
         trace!("{cmd:?}");
         self.load().await;
+        // A virtual entry has its outboard in the store but no data; the data
+        // is served on demand by the provider named in the entry. An entry
+        // whose provider is not registered (or whose provider has no data for
+        // this hash) is served as not found.
+        let is_virtual = matches!(self.state.borrow().deref(), BaoFileStorage::Virtual(_));
+        if is_virtual {
+            let provider_name = {
+                let state = self.state.borrow();
+                match state.deref() {
+                    BaoFileStorage::Virtual(v) => v.provider.clone(),
+                    _ => unreachable!("checked above"),
+                }
+            };
+            let Some(provider) = self.global.virtuals.get(&provider_name) else {
+                cmd.tx
+                    .send(
+                        bao_tree::io::EncodeError::Io(io::Error::new(
+                            io::ErrorKind::NotFound,
+                            "no provider registered for virtual entry",
+                        ))
+                        .into(),
+                    )
+                    .await
+                    .ok();
+                return;
+            };
+            let Some(source) = provider.reader_for(&self.id) else {
+                cmd.tx
+                    .send(
+                        bao_tree::io::EncodeError::Io(io::Error::new(
+                            io::ErrorKind::NotFound,
+                            "provider has no data for virtual entry",
+                        ))
+                        .into(),
+                    )
+                    .await
+                    .ok();
+                return;
+            };
+            let outboard = match self.outboard() {
+                Ok(o) => o,
+                Err(cause) => {
+                    cmd.tx
+                        .send(bao_tree::io::EncodeError::Io(cause).into())
+                        .await
+                        .ok();
+                    return;
+                }
+            };
+            let tx = BaoTreeSender::new(&mut cmd.tx);
+            traverse_ranges_validated(DynReadBytesAt(source), outboard, &cmd.inner.ranges, tx)
+                .await
+                .ok();
+            return;
+        }
         if let Err(cause) = export_bao_impl(self, cmd.inner, &mut cmd.tx).await {
             // if the entry is in state NonExisting, this will be an io error with
             // kind NotFound. So we must not wrap this somehow but pass it on directly.
@@ -1007,6 +1123,136 @@ impl EntityApi for HashContext {
             false
         });
     }
+}
+
+/// Store a virtual entry: outboard only, no data. The data is served later by
+/// the provider named in the entry, registered in
+/// [`crate::store::virtual_blob::VirtualProviders`].
+async fn finish_build_outboard_impl(
+    ctx: &TaskContext,
+    hash: Hash,
+    outboard: MemOrFile<Bytes, PathBuf>,
+    size: u64,
+) -> io::Result<()> {
+    let outboard_location = match outboard {
+        MemOrFile::Mem(bytes) if bytes.is_empty() => OutboardLocation::NotNeeded,
+        MemOrFile::Mem(bytes) => OutboardLocation::Inline(bytes),
+        MemOrFile::File(path) => {
+            // Mirror `finish_import_impl`: keep the outboard as a file in the
+            // canonical location rather than inlining it, so large virtual
+            // outboards don't bloat the database.
+            let target = ctx.options.path.outboard_path(&hash);
+            trace!(
+                "moving temp outboard file to owned outboard location: {} -> {}",
+                path.display(),
+                target.display()
+            );
+            if let Err(cause) = std::fs::rename(&path, &target) {
+                error!(
+                    "failed to move temp outboard file {} to owned outboard location {}: {cause}",
+                    path.display(),
+                    target.display()
+                );
+            }
+            OutboardLocation::Owned
+        }
+    };
+    let state = EntryState::Virtual {
+        outboard_location,
+        size,
+        provider: String::new(),
+    };
+    ctx.db.set(hash, state).await
+}
+
+/// Install a caller-supplied bao outboard as a virtual entry.
+///
+/// This is the store-side half for getters that received a blob's verified
+/// content without importing it (see `Remote::fetch_bao_to`). Validates the
+/// outboard against `size`, rejects entries that already hold stored or
+/// partial data, then decides inline-vs-file placement like
+/// [`finish_build_outboard_impl`] and stores the virtual entry.
+#[instrument(skip_all, fields(hash = %cmd.inner.hash.fmt_short()))]
+async fn add_virtual_with_outboard(cmd: AddVirtualWithOutboardMsg, ctx: Arc<TaskContext>) {
+    let AddVirtualWithOutboardMsg {
+        inner:
+            AddVirtualWithOutboardRequest {
+                hash,
+                size,
+                outboard,
+                provider,
+            },
+        tx,
+        ..
+    } = cmd;
+    // The outboard must match the size: one 64-byte hash pair per non-root
+    // tree node, and nothing at all for a single-chunk blob.
+    if outboard.len() as u64 != raw_outboard_size(size) {
+        tx.send(Err(crate::api::Error::io(
+            io::ErrorKind::InvalidInput,
+            "outboard length does not match blob size",
+        )))
+        .await
+        .ok();
+        return;
+    }
+    // Stored data takes precedence over a virtual source. Check before any
+    // file work so we never touch an existing entry's outboard file. The check
+    // is advisory; `set` below is unconditional, mirroring
+    // `finish_build_outboard_impl`.
+    let snapshot = match ctx.db.snapshot(Span::current()).await {
+        Ok(snapshot) => snapshot,
+        Err(cause) => {
+            tx.send(Err(crate::api::Error::from(cause))).await.ok();
+            return;
+        }
+    };
+    let existing = match snapshot.blobs.get(&hash) {
+        Ok(existing) => existing,
+        Err(cause) => {
+            tx.send(Err(crate::api::Error::other(cause))).await.ok();
+            return;
+        }
+    };
+    if let Some(state) = existing {
+        if matches!(state.value(), EntryState::Complete { .. } | EntryState::Partial { .. }) {
+            tx.send(Err(crate::api::Error::io(
+                io::ErrorKind::InvalidInput,
+                "entry already exists as stored data",
+            )))
+            .await
+            .ok();
+            return;
+        }
+    }
+    drop(snapshot);
+    let outboard_location = if outboard.is_empty() {
+        OutboardLocation::NotNeeded
+    } else if ctx.options.is_inlined_outboard(outboard.len() as u64) {
+        OutboardLocation::Inline(outboard)
+    } else {
+        // Mirror `finish_build_outboard_impl`: keep large outboards as a file
+        // in the canonical location rather than inlining them.
+        let target = ctx.options.path.outboard_path(&hash);
+        if let Err(cause) = std::fs::write(&target, &outboard) {
+            error!(
+                "failed to write outboard file {} for virtual entry: {cause}",
+                target.display()
+            );
+            tx.send(Err(crate::api::Error::from(cause))).await.ok();
+            return;
+        }
+        OutboardLocation::Owned
+    };
+    let state = EntryState::Virtual {
+        outboard_location,
+        size,
+        provider,
+    };
+    match ctx.db.set(hash, state).await {
+        Ok(()) => tx.send(Ok(())).await.ok(),
+        Err(cause) => tx.send(Err(crate::api::Error::from(cause))).await.ok(),
+    };
 }
 
 async fn finish_import_impl(ctx: &HashContext, import_data: ImportEntry) -> io::Result<()> {
@@ -1241,6 +1487,12 @@ async fn export_path_impl(
                 "cannot export partial entry",
             ));
         }
+        Some(EntryState::Virtual { .. }) => {
+            return Err(api::Error::io(
+                io::ErrorKind::InvalidInput,
+                "cannot export a virtual entry to a path; it has no stored data",
+            ));
+        }
         None => {
             return Err(api::Error::io(io::ErrorKind::NotFound, "no entry found"));
         }
@@ -1410,7 +1662,7 @@ impl FsStore {
         let (commands_tx, commands_rx) = tokio::sync::mpsc::channel(100);
         let (fs_commands_tx, fs_commands_rx) = tokio::sync::mpsc::channel(100);
         let gc_config = options.gc.clone();
-        let actor = handle
+        let (actor, virtuals) = handle
             .spawn(Actor::new(
                 db_path,
                 rt.into(),
@@ -1426,7 +1678,52 @@ impl FsStore {
         if let Some(config) = gc_config {
             handle.spawn(run_gc(store.deref().clone(), config));
         }
+        let _ = virtuals; // unused in load_with_opts; use load_with_virtuals to obtain it.
         Ok(store)
+    }
+
+    /// Load or create a new store with custom options, returning both the store
+    /// and a [`VirtualProviders`] registry shared with the store actor.
+    ///
+    /// The registry is used to register live providers for virtual blobs (see
+    /// [`crate::store::virtual_blob::VirtualProviders`]). It is the "add"
+    /// half of the two-layer virtual blob API; pair it with
+    /// [`crate::api::blobs::Blobs::build_outboard`].
+    pub async fn load_with_virtuals(
+        db_path: PathBuf,
+        options: Options,
+    ) -> Result<(FsStore, VirtualProviders)> {
+        static THREAD_NR: AtomicU64 = AtomicU64::new(0);
+        let rt = tokio::runtime::Builder::new_multi_thread()
+            .thread_name_fn(|| {
+                format!(
+                    "iroh-blob-store-{}",
+                    THREAD_NR.fetch_add(1, Ordering::Relaxed)
+                )
+            })
+            .enable_time()
+            .build()?;
+        let handle = rt.handle().clone();
+        let (commands_tx, commands_rx) = tokio::sync::mpsc::channel(100);
+        let (fs_commands_tx, fs_commands_rx) = tokio::sync::mpsc::channel(100);
+        let gc_config = options.gc.clone();
+        let (actor, virtuals) = handle
+            .spawn(Actor::new(
+                db_path,
+                rt.into(),
+                commands_rx,
+                fs_commands_rx,
+                fs_commands_tx.clone(),
+                Arc::new(options),
+            ))
+            .await
+            .anyerr()??;
+        handle.spawn(actor.run());
+        let store = FsStore::new(commands_tx.into(), fs_commands_tx);
+        if let Some(config) = gc_config {
+            handle.spawn(run_gc(store.deref().clone(), config));
+        }
+        Ok((store, virtuals))
     }
 }
 
@@ -1504,6 +1801,7 @@ pub mod tests {
     use walkdir::WalkDir;
 
     use super::*;
+    use crate::store::virtual_blob::{DynVirtualSource, Provider};
     use crate::{
         api::blobs::Bitfield,
         store::{
@@ -1589,7 +1887,173 @@ pub mod tests {
         }
         Bytes::from(res)
     }
+    /// A provider that serves a fixed set of bytes for any hash.
+    #[derive(Clone)]
+    struct TestProvider {
+        data: Bytes,
+    }
 
+    impl TestProvider {
+        fn new(data: Bytes) -> Self {
+            Self { data }
+        }
+    }
+
+    impl Provider for TestProvider {
+        fn reader_for(&self, _hash: &Hash) -> Option<DynVirtualSource> {
+            Some(Arc::new(self.data.clone()))
+        }
+    }
+
+    /// A virtual blob on the fs store: build the outboard from a stream
+    /// without storing data, associate a provider, register it, and serve. The
+    /// served bytes must be byte-identical to a normally-stored blob and
+    /// round-trip through `import_bao`.
+    #[tokio::test]
+    async fn virtual_blob_roundtrip_fs() -> TestResult<()> {
+        use std::sync::Arc;
+
+        let testdir = tempfile::tempdir()?;
+        let (store, virtuals) = FsStore::load_with_virtuals(
+            testdir.path().join("blobs.db"),
+            Options::new(testdir.path()),
+        )
+        .await?;
+        let data = test_data(1024 * 64);
+
+        // Build the outboard from a stream of the data, without storing it.
+        let stream = stream::iter(vec![Ok::<_, std::io::Error>(data.clone())]);
+        let tt = store.build_outboard(stream).await.temp_tag().await?;
+        let hash = tt.hash();
+
+        // An entry with no provider declared is served as not found.
+        let err: crate::api::Error = store
+            .export_bao(hash, ChunkRanges::all())
+            .bao_to_vec()
+            .await
+            .unwrap_err()
+            .into();
+        assert!(
+            matches!(err, crate::api::Error::Io(e) if e.kind() == io::ErrorKind::NotFound),
+            "virtual fs entry without a provider must serve as not found"
+        );
+
+        // Declaring a provider that is not registered is still not found.
+        store.add_virtual(hash, "test-provider").await?;
+        let err: crate::api::Error = store
+            .export_bao(hash, ChunkRanges::all())
+            .bao_to_vec()
+            .await
+            .unwrap_err()
+            .into();
+        assert!(
+            matches!(err, crate::api::Error::Io(e) if e.kind() == io::ErrorKind::NotFound),
+            "virtual fs entry with an unregistered provider must serve as not found"
+        );
+
+        // Register the provider and serve.
+        virtuals.register("test-provider", Arc::new(TestProvider::new(data.clone())))?;
+        let exported_virtual = store
+            .export_bao(hash, ChunkRanges::all())
+            .bao_to_vec()
+            .await?;
+
+        // Compare against a normal stored blob of identical content.
+        let store2 = FsStore::load(testdir.path().join("store2")).await?;
+        let tt2 = store2.add_bytes(data.clone()).temp_tag().await?;
+        assert_eq!(tt2.hash(), hash, "hashes must match for identical content");
+        let exported_stored = store2
+            .export_bao(hash, ChunkRanges::all())
+            .bao_to_vec()
+            .await?;
+        assert_eq!(
+            exported_virtual, exported_stored,
+            "virtual fs export must be byte-identical to stored export"
+        );
+
+        // Round-trip through import_bao back to the data.
+        let store3 = FsStore::load(testdir.path().join("store3")).await?;
+        store3
+            .import_bao_bytes(hash, ChunkRanges::all(), exported_virtual.clone())
+            .await?;
+        let got = store3.get_bytes(hash).await?;
+        assert_eq!(got, data, "round-tripped data must match the original");
+
+        Ok(())
+    }
+
+    /// A virtual blob whose outboard exceeds the inline threshold is stored as
+    /// an outboard file (mirroring normal large blobs), not inlined into the
+    /// database.
+    #[tokio::test]
+    async fn virtual_blob_large_outboard_fs() -> TestResult<()> {
+        use std::sync::Arc;
+
+        let testdir = tempfile::tempdir()?;
+        let options = Options::new(testdir.path());
+        let (store, virtuals) =
+            FsStore::load_with_virtuals(testdir.path().join("blobs.db"), options.clone()).await?;
+        // 8 MiB of data yields an outboard above the default 16 KiB inline
+        // threshold (see `INTERESTING_SIZES`), so it must go to a file.
+        let data = test_data(1024 * 1024 * 8);
+        let stream = stream::iter(vec![Ok::<_, std::io::Error>(data.clone())]);
+        let tt = store.build_outboard(stream).await.temp_tag().await?;
+        let hash = tt.hash();
+
+        // The outboard must live at the canonical outboard file location.
+        let outboard_path = options.path.outboard_path(&hash);
+        assert!(
+            outboard_path.exists(),
+            "large virtual outboard must be stored as a file at {}",
+            outboard_path.display()
+        );
+
+        // Serving reads the outboard file and the provider data.
+        virtuals.register("test-provider", Arc::new(TestProvider::new(data.clone())))?;
+        store.add_virtual(hash, "test-provider").await?;
+        let exported = store
+            .export_bao(hash, ChunkRanges::all())
+            .bao_to_vec()
+            .await?;
+        assert!(!exported.is_empty());
+
+        // And the export must round-trip to the original data.
+        let store2 = FsStore::load(testdir.path().join("store2")).await?;
+        store2
+            .import_bao_bytes(hash, ChunkRanges::all(), exported)
+            .await?;
+        let got = store2.get_bytes(hash).await?;
+        assert_eq!(got, data, "round-tripped data must match the original");
+        Ok(())
+    }
+
+    /// A virtual fs entry reports as `Complete` for status/has purposes (it is
+    /// servable), even though it has no stored data.
+    #[tokio::test]
+    async fn virtual_entry_status_fs() -> TestResult<()> {
+        use crate::api::blobs::BlobStatus;
+
+        let testdir = tempfile::tempdir()?;
+        let (store, _virtuals) = FsStore::load_with_virtuals(
+            testdir.path().join("blobs.db"),
+            Options::new(testdir.path()),
+        )
+        .await?;
+        let data = test_data(1024 * 64);
+        let stream = stream::iter(vec![Ok::<_, std::io::Error>(data.clone())]);
+        let tt = store.build_outboard(stream).await.temp_tag().await?;
+        let hash = tt.hash();
+
+        assert!(
+            store.has(hash).await?,
+            "virtual entry should be reported as present"
+        );
+        match store.status(hash).await? {
+            BlobStatus::Complete { size } => assert_eq!(size, data.len() as u64),
+            other => panic!("expected Complete for virtual entry, got {other:?}"),
+        }
+        Ok(())
+    }
     // import data via import_bytes, check that we can observe it and that it is complete
     #[tokio::test]
     async fn test_import_byte_stream() -> TestResult<()> {

--- a/src/store/fs.rs
+++ b/src/store/fs.rs
@@ -104,11 +104,10 @@ use tracing::{error, instrument, trace, Span};
 use crate::{
     api::{
         proto::{
-            self, bitfield::is_validated, BatchMsg, BatchResponse, Bitfield, Command,
-            CreateTempTagMsg, ExportBaoMsg, ExportBaoRequest, ExportPathMsg, ExportPathRequest,
-            ExportRangesItem, ExportRangesMsg, ExportRangesRequest, HashSpecific, ImportBaoMsg,
-            ImportBaoRequest, ObserveMsg, Scope, AddVirtualWithOutboardMsg,
-            AddVirtualWithOutboardRequest,
+            self, bitfield::is_validated, AddVirtualWithOutboardMsg, AddVirtualWithOutboardRequest,
+            BatchMsg, BatchResponse, Bitfield, Command, CreateTempTagMsg, ExportBaoMsg,
+            ExportBaoRequest, ExportPathMsg, ExportPathRequest, ExportRangesItem, ExportRangesMsg,
+            ExportRangesRequest, HashSpecific, ImportBaoMsg, ImportBaoRequest, ObserveMsg, Scope,
         },
         ApiClient,
     },
@@ -1215,7 +1214,10 @@ async fn add_virtual_with_outboard(cmd: AddVirtualWithOutboardMsg, ctx: Arc<Task
         }
     };
     if let Some(state) = existing {
-        if matches!(state.value(), EntryState::Complete { .. } | EntryState::Partial { .. }) {
+        if matches!(
+            state.value(),
+            EntryState::Complete { .. } | EntryState::Partial { .. }
+        ) {
             tx.send(Err(crate::api::Error::io(
                 io::ErrorKind::InvalidInput,
                 "entry already exists as stored data",

--- a/src/store/fs/bao_file.rs
+++ b/src/store/fs/bao_file.rs
@@ -81,6 +81,45 @@ impl CompleteStorage {
     }
 }
 
+/// Storage for a virtual blob: the outboard is stored, but there is no data.
+/// The data is served on demand by a provider registered in
+/// [`crate::store::virtual_blob::VirtualProviders`] under the entry's provider
+/// name.
+pub struct VirtualStorage {
+    /// The outboard, in memory or on disk.
+    pub outboard: MemOrFile<Bytes, File>,
+    /// The total size of the (unstored) data.
+    pub size: u64,
+    /// The name of the provider that serves this entry's data.
+    pub provider: String,
+}
+
+impl VirtualStorage {
+    pub fn new(outboard: MemOrFile<Bytes, File>, size: u64, provider: String) -> Self {
+        Self {
+            outboard,
+            size,
+            provider,
+        }
+    }
+
+    pub fn size(&self) -> u64 {
+        self.size
+    }
+
+    pub fn bitfield(&self) -> Bitfield {
+        Bitfield::complete(self.size)
+    }
+}
+
+impl fmt::Debug for VirtualStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("VirtualStorage")
+            .field("outboard", &DD(self.outboard.fmt_short()))
+            .field("size", &self.size)
+            .finish()
+    }
+}
 /// Create a file for reading and writing, but *without* truncating the existing
 /// file.
 fn create_read_write(path: impl AsRef<Path>) -> io::Result<File> {
@@ -322,6 +361,10 @@ pub(crate) enum BaoFileStorage {
     ///
     /// Writing to this is a no-op, since it is already complete.
     Complete(CompleteStorage),
+    /// A virtual entry: the outboard is stored, but the data is not. The data
+    /// is served on demand by the provider named in the entry, registered in
+    /// [`crate::store::virtual_blob::VirtualProviders`].
+    Virtual(VirtualStorage),
     /// We will get into that state if there is an io error in the middle of an operation,
     /// or after the handle is persisted and no longer usable.
     Poisoned,
@@ -333,6 +376,7 @@ impl fmt::Debug for BaoFileStorage {
             BaoFileStorage::PartialMem(x) => x.fmt(f),
             BaoFileStorage::Partial(x) => x.fmt(f),
             BaoFileStorage::Complete(x) => x.fmt(f),
+            BaoFileStorage::Virtual(x) => x.fmt(f),
             BaoFileStorage::Poisoned => f.debug_struct("Poisoned").finish(),
             BaoFileStorage::Initial => f.debug_struct("Initial").finish(),
             BaoFileStorage::Loading => f.debug_struct("Loading").finish(),
@@ -406,6 +450,7 @@ impl BaoFileStorage {
             BaoFileStorage::PartialMem(x) => x.bitfield.clone(),
             BaoFileStorage::Partial(x) => x.bitfield.clone(),
             BaoFileStorage::Complete(x) => Bitfield::complete(x.data.size()),
+            BaoFileStorage::Virtual(x) => x.bitfield(),
             BaoFileStorage::Poisoned => {
                 panic!("poisoned storage should not be used")
             }
@@ -501,6 +546,7 @@ impl BaoFileStorage {
     fn sync_all(&self) -> io::Result<()> {
         match self {
             Self::Complete(_) => Ok(()),
+            Self::Virtual(_) => Ok(()),
             Self::PartialMem(_) => Ok(()),
             Self::NonExisting => Ok(()),
             Self::Partial(file) => {
@@ -546,6 +592,9 @@ impl ReadBytesAt for DataReader {
             BaoFileStorage::PartialMem(x) => x.data.read_bytes_at(offset, size),
             BaoFileStorage::Partial(x) => x.data.read_bytes_at(offset, size),
             BaoFileStorage::Complete(x) => x.data.read_bytes_at(offset, size),
+            BaoFileStorage::Virtual(_) => Err(io::Error::other(
+                "virtual entry has no stored data; serve via a registered provider",
+            )),
             BaoFileStorage::Poisoned => io::Result::Err(io::Error::other("poisoned storage")),
             BaoFileStorage::Initial => io::Result::Err(io::Error::other("initial")),
             BaoFileStorage::Loading => io::Result::Err(io::Error::other("loading")),
@@ -563,6 +612,7 @@ impl ReadAt for OutboardReader {
         let guard = self.0.borrow();
         match guard.deref() {
             BaoFileStorage::Complete(x) => x.outboard.read_at(offset, buf),
+            BaoFileStorage::Virtual(x) => x.outboard.read_at(offset, buf),
             BaoFileStorage::PartialMem(x) => x.outboard.read_at(offset, buf),
             BaoFileStorage::Partial(x) => x.outboard.read_at(offset, buf),
             BaoFileStorage::Poisoned => io::Result::Err(io::Error::other("poisoned storage")),
@@ -609,6 +659,22 @@ impl BaoFileStorage {
                 Self::new_complete(data, outboard)
             }
             Some(EntryState::Partial { .. }) => Self::new_partial_file(ctx).await?,
+            Some(EntryState::Virtual {
+                outboard_location,
+                size,
+                provider,
+            }) => {
+                let outboard = match outboard_location {
+                    OutboardLocation::NotNeeded => MemOrFile::empty(),
+                    OutboardLocation::Inline(data) => MemOrFile::Mem(data),
+                    OutboardLocation::Owned => {
+                        let path = options.path.outboard_path(hash);
+                        let file = std::fs::File::open(&path)?;
+                        MemOrFile::File(file)
+                    }
+                };
+                Self::Virtual(VirtualStorage::new(outboard, size, provider))
+            }
             None => Self::NonExisting,
         })
     }

--- a/src/store/fs/entry_state.rs
+++ b/src/store/fs/entry_state.rs
@@ -168,7 +168,7 @@ pub enum EntryState<I = ()> {
         outboard_location: OutboardLocation<I>,
     },
     /// Partial entries are entries for which we know the hash, but don't have
-    /// all the data. They are created when syncing from somewhere else by hash.
+    /// all the data. They are created when syncing from somewhere by hash.
     ///
     /// As such they are always owned. There is also no inline storage for them.
     /// Non short lived partial entries always live in the file system, and for
@@ -180,6 +180,21 @@ pub enum EntryState<I = ()> {
         /// E.g. a giant file where we just requested the last chunk.
         size: Option<u64>,
     },
+    /// A virtual entry: the outboard is stored, but the data is not. The data
+    /// is served on demand by a provider registered in
+    /// [`crate::store::virtual_blob::VirtualProviders`] under the entry's
+    /// provider name.
+    Virtual {
+        /// Location of the outboard.
+        outboard_location: OutboardLocation<I>,
+        /// The total size of the (unstored) data.
+        size: u64,
+        /// The name of the provider that serves this entry's data.
+        ///
+        /// Set via [`crate::api::blobs::Blobs::add_virtual`]. Empty until then;
+        /// an entry without a provider name is served as not found.
+        provider: String,
+    },
 }
 
 impl<I> EntryState<I> {
@@ -189,6 +204,11 @@ impl<I> EntryState<I> {
 
     pub fn is_partial(&self) -> bool {
         matches!(self, Self::Partial { .. })
+    }
+
+    /// True for a virtual entry (outboard stored, data served from a live source).
+    pub fn is_virtual(&self) -> bool {
+        matches!(self, Self::Virtual { .. })
     }
 }
 
@@ -210,6 +230,14 @@ impl<I: AsRef<[u8]>> EntryState<I> {
                 outboard_location.fmt_short()
             ),
             Self::Partial { size } => format!("Partial {{ size: {size:?} }}"),
+            Self::Virtual {
+                outboard_location,
+                size,
+                provider,
+            } => format!(
+                "Virtual {{ outboard: {}, size: {size}, provider: {provider:?} }}",
+                outboard_location.fmt_short()
+            ),
         }
     }
 }
@@ -263,6 +291,15 @@ impl EntryState {
                 };
                 Ok(Self::Partial { size })
             }
+            // A complete entry has real data, which always wins over a virtual
+            // (data-less) entry.
+            (a @ Self::Complete { .. }, Self::Virtual { .. }) => Ok(a),
+            (Self::Virtual { .. }, b @ Self::Complete { .. }) => Ok(b),
+            // A virtual entry is preferable to a partial one (it is servable).
+            (a @ Self::Virtual { .. }, Self::Partial { .. }) => Ok(a),
+            (Self::Partial { .. }, b @ Self::Virtual { .. }) => Ok(b),
+            // Two virtual entries for the same hash are equivalent; keep `old`.
+            (a @ Self::Virtual { .. }, Self::Virtual { .. }) => Ok(a),
         }
     }
 }

--- a/src/store/fs/import.rs
+++ b/src/store/fs/import.rs
@@ -33,13 +33,14 @@ use ref_cast::RefCast;
 use smallvec::SmallVec;
 use tracing::{instrument, trace};
 
-use super::{meta::raw_outboard_size, options::Options, TaskContext};
+use super::{meta::raw_outboard_size, options::Options, FinishBuildOutboardMsg, TaskContext};
 use crate::{
     api::{
         blobs::{AddProgressItem, ImportMode},
         proto::{
-            HashSpecific, ImportByteStreamMsg, ImportByteStreamRequest, ImportByteStreamUpdate,
-            ImportBytesMsg, ImportBytesRequest, ImportPathMsg, ImportPathRequest, Request, Scope,
+            BuildOutboardMsg, HashSpecific, ImportByteStreamMsg, ImportByteStreamRequest,
+            ImportByteStreamUpdate, ImportBytesMsg, ImportBytesRequest, ImportPathMsg,
+            ImportPathRequest, Request, Scope,
         },
     },
     store::{
@@ -224,6 +225,51 @@ async fn import_bytes_tiny_impl(
 pub async fn import_byte_stream(cmd: ImportByteStreamMsg, ctx: Arc<TaskContext>) {
     let stream = into_stream(cmd.rx);
     import_byte_stream_mid(cmd.inner, cmd.tx, cmd.span, stream, ctx).await
+}
+
+/// Build the BLAKE3 outboard for a stream of bytes without storing the data.
+///
+/// Reuses the import machinery to compute the outboard, then discards the data
+/// (deleting any temp data file) and sends a [`FinishBuildOutboardMsg`] so the
+/// actor stores the outboard as a virtual entry.
+#[instrument(skip_all)]
+pub(crate) async fn build_outboard(cmd: BuildOutboardMsg, ctx: Arc<TaskContext>) {
+    let BuildOutboardMsg {
+        inner,
+        mut tx,
+        rx,
+        span,
+        ..
+    } = cmd;
+    let stream = into_stream(rx);
+    let request = ImportByteStreamRequest {
+        format: inner.format,
+        scope: inner.scope,
+    };
+    let entry = match import_byte_stream_impl(request, &mut tx, stream, ctx.options.clone()).await {
+        Ok(entry) => entry,
+        Err(cause) => {
+            tx.send(cause.into()).await.ok();
+            return;
+        }
+    };
+    let size = entry.source.size();
+    // The data is intentionally not retained. Delete any temp data file.
+    if let ImportSource::TempFile(path, _file, _size) = entry.source {
+        let _ = std::fs::remove_file(&path);
+    }
+    // Keep the outboard as-is (in memory or as a temp file); the finish step
+    // decides whether to inline it or move it to the canonical outboard file.
+    let msg = FinishBuildOutboardMsg {
+        hash: entry.hash,
+        scope: entry.scope,
+        format: entry.format,
+        outboard: entry.outboard,
+        size,
+        tx,
+        span,
+    };
+    ctx.internal_cmd_tx.send(msg.into()).await.ok();
 }
 
 fn into_stream(

--- a/src/store/fs/meta.rs
+++ b/src/store/fs/meta.rs
@@ -20,9 +20,9 @@ use crate::{
         self,
         blobs::BlobStatus,
         proto::{
-            BlobDeleteRequest, BlobStatusMsg, BlobStatusRequest, ClearProtectedMsg,
-            CreateTagRequest, DeleteBlobsMsg, DeleteTagsRequest, ListBlobsMsg, ListRequest,
-            ListTagsRequest, RenameTagRequest, SetTagRequest, ShutdownMsg, SyncDbMsg,
+            AddVirtualMsg, AddVirtualRequest, BlobDeleteRequest, BlobStatusMsg, BlobStatusRequest,
+            ClearProtectedMsg, CreateTagRequest, DeleteBlobsMsg, DeleteTagsRequest, ListBlobsMsg,
+            ListRequest, ListTagsRequest, RenameTagRequest, SetTagRequest, ShutdownMsg, SyncDbMsg,
         },
         tags::TagInfo,
         Tag,
@@ -223,6 +223,18 @@ fn handle_get(cmd: Get, tables: &impl ReadableTables) -> ActorResult<()> {
             }
         }
         EntryState::Partial { size } => EntryState::Partial { size },
+        EntryState::Virtual {
+            outboard_location,
+            size,
+            provider,
+        } => {
+            let outboard_location = load_outboard(tables, outboard_location, &hash)?;
+            EntryState::Virtual {
+                outboard_location,
+                size,
+                provider,
+            }
+        }
     };
     tx.send(GetResult {
         state: Ok(Some(entry)),
@@ -323,6 +335,7 @@ async fn handle_get_blob_status(
                 DataLocation::External(_, size) => BlobStatus::Complete { size },
             },
             EntryState::Partial { size } => BlobStatus::Partial { size },
+            EntryState::Virtual { size, .. } => BlobStatus::Complete { size },
         },
         None => BlobStatus::NotFound,
     };
@@ -399,6 +412,22 @@ fn handle_update(
             )
         }
         EntryState::Partial { size } => (EntryState::Partial { size }, None, None),
+        EntryState::Virtual {
+            outboard_location,
+            size,
+            provider,
+        } => {
+            let (outboard_location, outboard) = outboard_location.split_inline_data();
+            (
+                EntryState::Virtual {
+                    outboard_location,
+                    size,
+                    provider,
+                },
+                None,
+                outboard,
+            )
+        }
     };
     let state = match old_entry_opt {
         Some(old) => {
@@ -458,6 +487,22 @@ fn handle_set(cmd: Set, protected: &mut HashSet<Hash>, tables: &mut Tables) -> A
             )
         }
         EntryState::Partial { size } => (EntryState::Partial { size }, None, None),
+        EntryState::Virtual {
+            outboard_location,
+            size,
+            provider,
+        } => {
+            let (outboard_location, outboard) = outboard_location.split_inline_data();
+            (
+                EntryState::Virtual {
+                    outboard_location,
+                    size,
+                    provider,
+                },
+                None,
+                outboard,
+            )
+        }
     };
     tables
         .blobs
@@ -614,6 +659,20 @@ impl Actor {
                             ],
                         );
                     }
+                    EntryState::Virtual {
+                        outboard_location, ..
+                    } => {
+                        trace!("delete {hash}: currently virtual. will be deleted.");
+                        match outboard_location {
+                            OutboardLocation::Inline(_) => {
+                                tables.inline_outboard.remove(hash)?;
+                            }
+                            OutboardLocation::Owned => {
+                                tables.ftx.delete(hash, [BaoFilePart::Outboard]);
+                            }
+                            OutboardLocation::NotNeeded => {}
+                        }
+                    }
                 }
             }
         }
@@ -699,6 +758,54 @@ impl Actor {
         Ok(())
     }
 
+    /// Set the provider name of a virtual entry (see
+    /// [`crate::api::blobs::Blobs::add_virtual`]).
+    async fn add_virtual(
+        protected: &mut HashSet<Hash>,
+        tables: &mut Tables<'_>,
+        cmd: AddVirtualMsg,
+    ) -> ActorResult<()> {
+        trace!("{cmd:?}");
+        let AddVirtualMsg {
+            inner: AddVirtualRequest { hash, provider },
+            tx,
+            ..
+        } = cmd;
+        let entry = match tables.blobs.get(hash)?.map(|e| e.value()) {
+            Some(EntryState::Virtual {
+                outboard_location,
+                size,
+                ..
+            }) => EntryState::Virtual {
+                outboard_location,
+                size,
+                provider,
+            },
+            Some(_) => {
+                tx.send(Err(api::Error::io(
+                    io::ErrorKind::InvalidInput,
+                    "entry is not virtual",
+                )))
+                .await
+                .ok();
+                return Ok(());
+            }
+            None => {
+                tx.send(Err(api::Error::io(
+                    io::ErrorKind::NotFound,
+                    "no virtual entry for hash",
+                )))
+                .await
+                .ok();
+                return Ok(());
+            }
+        };
+        protected.insert(hash);
+        tables.blobs.insert(hash, entry)?;
+        tx.send(Ok(())).await.ok();
+        Ok(())
+    }
+
     async fn handle_readwrite(
         protected: &mut HashSet<Hash>,
         tables: &mut Tables<'_>,
@@ -716,6 +823,7 @@ impl Actor {
             ReadWriteCommand::Set(cmd) => handle_set(cmd, protected, tables),
             ReadWriteCommand::DeleteBlobw(cmd) => Self::delete(protected, tables, cmd).await,
             ReadWriteCommand::SetTag(cmd) => Self::set_tag(tables, cmd).await,
+            ReadWriteCommand::AddVirtual(cmd) => Self::add_virtual(protected, tables, cmd).await,
             ReadWriteCommand::CreateTag(cmd) => Self::create_tag(tables, cmd).await,
             ReadWriteCommand::DeleteTags(cmd) => Self::delete_tags(tables, cmd).await,
             ReadWriteCommand::RenameTag(cmd) => Self::rename_tag(tables, cmd).await,

--- a/src/store/fs/meta/proto.rs
+++ b/src/store/fs/meta/proto.rs
@@ -89,6 +89,8 @@ impl fmt::Debug for Set {
     }
 }
 
+/// Modification method: associate a virtual entry with a provider name.
+pub use crate::api::proto::AddVirtualMsg;
 /// Modification method: create a new unique tag and set it to a value.
 pub use crate::api::proto::CreateTagMsg;
 /// Modification method: remove a range of tags.
@@ -135,6 +137,7 @@ pub enum ReadWriteCommand {
     Set(Set),
     DeleteBlobw(DeleteBlobsMsg),
     SetTag(SetTagMsg),
+    AddVirtual(AddVirtualMsg),
     DeleteTags(DeleteTagsMsg),
     RenameTag(RenameTagMsg),
     CreateTag(CreateTagMsg),
@@ -154,6 +157,7 @@ impl ReadWriteCommand {
             Self::Set(x) => Some(&x.span),
             Self::DeleteBlobw(x) => Some(&x.span),
             Self::SetTag(x) => x.parent_span_opt(),
+            Self::AddVirtual(x) => x.parent_span_opt(),
             Self::DeleteTags(x) => x.parent_span_opt(),
             Self::RenameTag(x) => x.parent_span_opt(),
             Self::CreateTag(x) => x.parent_span_opt(),

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -39,15 +39,18 @@ use tokio::sync::watch;
 use tracing::{error, info, instrument, trace, Instrument};
 
 use super::util::{BaoTreeSender, PartialMemStorage};
+use super::virtual_blob::{DynReadBytesAt, VirtualProviders};
 use crate::{
     api::{
         self,
         blobs::{AddProgressItem, Bitfield, BlobStatus, ExportProgressItem},
         proto::{
-            BatchMsg, BatchResponse, BlobDeleteRequest, BlobStatusMsg, BlobStatusRequest, Command,
-            CreateTagMsg, CreateTagRequest, CreateTempTagMsg, DeleteBlobsMsg, DeleteTagsMsg,
-            DeleteTagsRequest, ExportBaoMsg, ExportBaoRequest, ExportPathMsg, ExportPathRequest,
-            ExportRangesItem, ExportRangesMsg, ExportRangesRequest, ImportBaoMsg, ImportBaoRequest,
+            AddVirtualMsg, AddVirtualRequest, AddVirtualWithOutboardMsg,
+            AddVirtualWithOutboardRequest, BatchMsg, BatchResponse, BlobDeleteRequest,
+            BlobStatusMsg, BlobStatusRequest, BuildOutboardMsg, Command, CreateTagMsg,
+            CreateTagRequest, CreateTempTagMsg, DeleteBlobsMsg, DeleteTagsMsg, DeleteTagsRequest,
+            ExportBaoMsg, ExportBaoRequest, ExportPathMsg, ExportPathRequest, ExportRangesItem,
+            ExportRangesMsg, ExportRangesRequest, ImportBaoMsg, ImportBaoRequest,
             ImportByteStreamMsg, ImportByteStreamUpdate, ImportBytesMsg, ImportBytesRequest,
             ImportPathMsg, ImportPathRequest, ListBlobsMsg, ListTagsMsg, ListTagsRequest,
             ObserveMsg, ObserveRequest, RenameTagMsg, RenameTagRequest, Scope, SetTagMsg,
@@ -107,7 +110,19 @@ impl Default for MemStore {
 enum TaskResult {
     Unit(()),
     Import(Result<ImportEntry>),
+    BuildOutboard(Result<BuildOutboardResult>),
     Scope(Scope),
+}
+
+/// The result of [`build_outboard`]: the computed hash, the outboard bytes, the
+/// total size, and the channels needed to finish registration.
+struct BuildOutboardResult {
+    hash: Hash,
+    outboard: Bytes,
+    size: u64,
+    scope: Scope,
+    format: BlobFormat,
+    tx: mpsc::Sender<AddProgressItem>,
 }
 
 impl MemStore {
@@ -119,8 +134,9 @@ impl MemStore {
         Self::new_with_opts(Options::default())
     }
 
-    pub fn new_with_opts(opts: Options) -> Self {
+    pub fn new_with_virtuals(opts: Options) -> (Self, VirtualProviders) {
         let (sender, receiver) = tokio::sync::mpsc::channel(32);
+        let virtuals = VirtualProviders::new();
         n0_future::task::spawn(
             Actor {
                 commands: receiver,
@@ -134,6 +150,7 @@ impl MemStore {
                 temp_tags: Default::default(),
                 protected: Default::default(),
                 idle_waiters: Default::default(),
+                virtuals: virtuals.clone(),
             }
             .run(),
         );
@@ -143,7 +160,11 @@ impl MemStore {
             n0_future::task::spawn(run_gc(store.deref().clone(), gc_config));
         }
 
-        store
+        (store, virtuals)
+    }
+
+    pub fn new_with_opts(opts: Options) -> Self {
+        Self::new_with_virtuals(opts).0
     }
 }
 
@@ -158,6 +179,8 @@ struct Actor {
     // idle waiters
     idle_waiters: Vec<irpc::channel::oneshot::Sender<()>>,
     protected: HashSet<Hash>,
+    /// Live providers for virtual blobs, keyed by provider name.
+    virtuals: VirtualProviders,
 }
 
 impl Actor {
@@ -216,6 +239,89 @@ impl Actor {
             Command::ImportByteStream(ImportByteStreamMsg { inner, tx, rx, .. }) => {
                 self.spawn(import_byte_stream(inner.scope, inner.format, rx, tx));
             }
+            Command::BuildOutboard(BuildOutboardMsg { inner, tx, rx, .. }) => {
+                self.spawn(build_outboard(inner.scope, inner.format, rx, tx));
+            }
+            Command::AddVirtual(AddVirtualMsg {
+                inner: AddVirtualRequest { hash, provider },
+                tx,
+                ..
+            }) => match self.get(&hash) {
+                Some(entry) => {
+                    let modified = entry
+                        .0
+                        .state
+                        .send_if_modified(|state: &mut BaoFileStorage| {
+                            if let BaoFileStorage::Virtual(v) = state {
+                                v.provider = provider.clone();
+                                true
+                            } else {
+                                false
+                            }
+                        });
+                    let res = if modified {
+                        Ok(())
+                    } else {
+                        Err(api::Error::io(
+                            io::ErrorKind::InvalidInput,
+                            "entry is not virtual",
+                        ))
+                    };
+                    tx.send(res).await.ok();
+                }
+                None => {
+                    tx.send(Err(api::Error::io(
+                        io::ErrorKind::NotFound,
+                        "no virtual entry for hash",
+                    )))
+                    .await
+                    .ok();
+                }
+            },
+            Command::AddVirtualWithOutboard(AddVirtualWithOutboardMsg {
+                inner:
+                    AddVirtualWithOutboardRequest {
+                        hash,
+                        size,
+                        outboard,
+                        provider,
+                    },
+                tx,
+                ..
+            }) => {
+                // The outboard must match the size: one 64-byte hash pair per
+                // non-root tree node, and nothing at all for a single-chunk blob.
+                let res = if outboard.len() as u64 != BaoTree::new(size, IROH_BLOCK_SIZE).outboard_size()
+                {
+                    Err(api::Error::io(
+                        io::ErrorKind::InvalidInput,
+                        "outboard length does not match blob size",
+                    ))
+                } else {
+                    let entry = self.get_or_create_entry(hash);
+                    let modified = entry.0.state.send_if_modified(|state: &mut BaoFileStorage| {
+                        // Stored data takes precedence over a virtual source.
+                        if matches!(state.deref(), BaoFileStorage::Complete(_)) {
+                            return false;
+                        }
+                        *state = BaoFileStorage::Virtual(VirtualStorage::new(
+                            outboard.clone(),
+                            size,
+                            provider.clone(),
+                        ));
+                        true
+                    });
+                    if modified {
+                        Ok(())
+                    } else {
+                        Err(api::Error::io(
+                            io::ErrorKind::InvalidInput,
+                            "entry already exists as stored data",
+                        ))
+                    }
+                };
+                tx.send(res).await.ok();
+            }
             Command::ImportPath(cmd) => {
                 self.spawn(import_path(cmd));
             }
@@ -225,7 +331,8 @@ impl Actor {
                 ..
             }) => {
                 let entry = self.get(&hash);
-                self.spawn(export_bao(entry, ranges, tx))
+                let virtuals = self.virtuals.clone();
+                self.spawn(export_bao(entry, ranges, tx, virtuals))
             }
             Command::ExportPath(cmd) => {
                 let entry = self.get(&cmd.hash);
@@ -477,6 +584,47 @@ impl Actor {
         import_data.tx.send(AddProgressItem::Done(tt)).await.ok();
     }
 
+    /// Finish a [`build_outboard`] task: store the computed outboard as a
+    /// virtual entry (no data) and protect it with a temp tag.
+    ///
+    /// If an entry already exists as `Complete` or `Virtual`, it is left
+    /// untouched (store-before-virtual precedence).
+    async fn finish_build_outboard(&mut self, res: Result<BuildOutboardResult>) {
+        let r = match res {
+            Ok(r) => r,
+            Err(e) => {
+                error!("build_outboard failed: {e}");
+                return;
+            }
+        };
+        let entry = self.get_or_create_entry(r.hash);
+        entry
+            .0
+            .state
+            .send_if_modified(|state: &mut BaoFileStorage| {
+                // Only convert a fresh or in-progress Partial entry. A Complete
+                // entry (data already stored) or an existing Virtual entry is left
+                // untouched: stored data takes precedence over a virtual source.
+                if matches!(state.deref(), BaoFileStorage::Partial(_)) {
+                    *state = BaoFileStorage::Virtual(VirtualStorage::new(
+                        r.outboard.clone(),
+                        r.size,
+                        String::new(),
+                    ));
+                    return true;
+                }
+                false
+            });
+        let tt = self.temp_tags.create(
+            r.scope,
+            HashAndFormat {
+                hash: r.hash,
+                format: r.format,
+            },
+        );
+        r.tx.send(AddProgressItem::Done(tt)).await.ok();
+    }
+
     fn log_task_result(&self, res: Result<TaskResult, JoinError>) -> Option<TaskResult> {
         match res {
             Ok(x) => Some(x),
@@ -511,6 +659,9 @@ impl Actor {
                     match res {
                         TaskResult::Import(res) => {
                             self.finish_import(res).await;
+                        }
+                        TaskResult::BuildOutboard(res) => {
+                            self.finish_build_outboard(res).await;
                         }
                         TaskResult::Scope(scope) => {
                             self.temp_tags.end_scope(scope);
@@ -685,6 +836,7 @@ async fn export_bao(
     entry: Option<BaoFileHandle>,
     ranges: ChunkRanges,
     mut sender: mpsc::Sender<EncodedItem>,
+    virtuals: VirtualProviders,
 ) {
     let Some(entry) = entry else {
         let err = EncodeError::Io(io::Error::new(io::ErrorKind::NotFound, "hash not found"));
@@ -692,12 +844,95 @@ async fn export_bao(
         return;
     };
     tracing::Span::current().record("hash", tracing::field::display(entry.hash));
-    let data = entry.data_reader();
     let outboard = entry.outboard_reader();
-    let tx = BaoTreeSender::new(&mut sender);
-    traverse_ranges_validated(data, outboard, &ranges, tx)
-        .await
-        .ok();
+    let is_virtual = matches!(entry.0.state.borrow().deref(), BaoFileStorage::Virtual(_));
+    if is_virtual {
+        // Serve a virtual entry via the provider named in the entry. The
+        // outboard comes from the entry; the data comes from the provider via
+        // `VirtualProviders`. An entry whose provider is not registered (or
+        // whose provider has no data for this hash) is served as not found.
+        let provider_name = match entry.0.state.borrow().deref() {
+            BaoFileStorage::Virtual(v) => v.provider.clone(),
+            _ => unreachable!("checked above"),
+        };
+        let Some(provider) = virtuals.get(&provider_name) else {
+            let err = EncodeError::Io(io::Error::new(
+                io::ErrorKind::NotFound,
+                "no provider registered for virtual entry",
+            ));
+            sender.send(err.into()).await.ok();
+            return;
+        };
+        let Some(source) = provider.reader_for(&entry.hash) else {
+            let err = EncodeError::Io(io::Error::new(
+                io::ErrorKind::NotFound,
+                "provider has no data for virtual entry",
+            ));
+            sender.send(err.into()).await.ok();
+            return;
+        };
+        let tx = BaoTreeSender::new(&mut sender);
+        traverse_ranges_validated(DynReadBytesAt(source), outboard, &ranges, tx)
+            .await
+            .ok();
+    } else {
+        let data = entry.data_reader();
+        let tx = BaoTreeSender::new(&mut sender);
+        traverse_ranges_validated(data, outboard, &ranges, tx)
+            .await
+            .ok();
+    }
+}
+
+/// Build the BLAKE3 outboard for a stream of bytes without storing the data.
+///
+/// The bytes are accumulated, the outboard and root hash are computed, and the
+/// data is then discarded. The result is stored as a virtual entry by
+/// [`Actor::finish_build_outboard`].
+async fn build_outboard(
+    scope: Scope,
+    format: BlobFormat,
+    mut rx: mpsc::Receiver<ImportByteStreamUpdate>,
+    tx: mpsc::Sender<AddProgressItem>,
+) -> Result<BuildOutboardResult> {
+    let mut res = Vec::new();
+    loop {
+        match rx.recv().await {
+            Ok(Some(ImportByteStreamUpdate::Bytes(data))) => {
+                res.extend_from_slice(&data);
+                tx.send(AddProgressItem::CopyProgress(res.len() as u64))
+                    .await?;
+            }
+            Ok(Some(ImportByteStreamUpdate::Done)) => break,
+            Ok(None) => {
+                return Err(api::Error::io(
+                    io::ErrorKind::UnexpectedEof,
+                    "byte stream ended unexpectedly",
+                )
+                .into());
+            }
+            Err(e) => {
+                return Err(e.into());
+            }
+        }
+    }
+    tx.send(AddProgressItem::Size(res.len() as u64)).await?;
+    tx.send(AddProgressItem::CopyDone).await?;
+    let outboard = PreOrderMemOutboard::create(&res, IROH_BLOCK_SIZE);
+    let hash: Hash = outboard.root.into();
+    let size = res.len() as u64;
+    let outboard_bytes: Bytes = outboard.data.into();
+    // The data is intentionally not retained; a virtual entry stores only the
+    // outboard and is served from a registered live data source.
+    drop(res);
+    Ok(BuildOutboardResult {
+        hash,
+        outboard: outboard_bytes,
+        size,
+        scope,
+        format,
+        tx,
+    })
 }
 
 #[instrument(skip_all, fields(hash = %entry.hash.fmt_short()))]
@@ -906,6 +1141,32 @@ struct State {
 pub enum BaoFileStorage {
     Partial(PartialMemStorage),
     Complete(CompleteStorage),
+    /// A virtual entry: the outboard is stored, but the data is not. The data
+    /// is served on demand by the provider named in the entry, registered in
+    /// [`VirtualProviders`].
+    Virtual(VirtualStorage),
+}
+
+/// Stored outboard for a virtual blob, with no data.
+#[derive(Debug, Clone)]
+pub struct VirtualStorage {
+    pub(crate) outboard: Bytes,
+    pub(crate) size: u64,
+    /// The name of the provider that serves this entry's data.
+    pub(crate) provider: String,
+}
+
+impl VirtualStorage {
+    pub fn new(outboard: Bytes, size: u64, provider: String) -> Self {
+        Self {
+            outboard,
+            size,
+            provider,
+        }
+    }
+    pub fn size(&self) -> u64 {
+        self.size
+    }
 }
 
 impl BaoFileStorage {
@@ -914,6 +1175,7 @@ impl BaoFileStorage {
         match self {
             Self::Partial(entry) => entry.bitfield.clone(),
             Self::Complete(entry) => Bitfield::complete(entry.size()),
+            Self::Virtual(entry) => Bitfield::complete(entry.size()),
         }
     }
 }
@@ -936,6 +1198,16 @@ impl BaoFileHandle {
             size: SizeInfo::default(),
             bitfield: Bitfield::empty(),
         }));
+        Self(Arc::new(BaoFileHandleInner { state, hash }))
+    }
+
+    /// Create a virtual entry handle: outboard stored, no data.
+    pub fn new_virtual(hash: Hash, outboard: Bytes, size: u64) -> Self {
+        let (state, _) = watch::channel(BaoFileStorage::Virtual(VirtualStorage::new(
+            outboard,
+            size,
+            String::new(),
+        )));
         Self(Arc::new(BaoFileHandleInner { state, hash }))
     }
 
@@ -978,6 +1250,10 @@ impl BaoFileStorage {
         match self {
             Self::Partial(entry) => entry.data.as_ref(),
             Self::Complete(entry) => &entry.data,
+            // A virtual entry has no stored data; it is served from a live
+            // source. This is only reached via `DataReader`, which is not used
+            // for virtual entries (see `export_bao`).
+            Self::Virtual(_) => &[],
         }
     }
 
@@ -985,6 +1261,7 @@ impl BaoFileStorage {
         match self {
             Self::Partial(entry) => entry.outboard.as_ref(),
             Self::Complete(entry) => &entry.outboard,
+            Self::Virtual(entry) => &entry.outboard,
         }
     }
 
@@ -992,6 +1269,7 @@ impl BaoFileStorage {
         match self {
             Self::Partial(entry) => entry.current_size(),
             Self::Complete(entry) => entry.size(),
+            Self::Virtual(entry) => entry.size(),
         }
     }
 }
@@ -1087,10 +1365,10 @@ impl BaoFileStorageSubscriber {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use crate::store::virtual_blob::{DynVirtualSource, Provider};
     use n0_future::StreamExt;
     use testresult::TestResult;
-
-    use super::*;
 
     #[tokio::test]
     async fn smoke() -> TestResult<()> {
@@ -1122,6 +1400,142 @@ mod tests {
             .await?;
         assert_eq!(exported, exported2);
 
+        Ok(())
+    }
+
+    /// A provider that serves a fixed set of bytes for any hash.
+    #[derive(Clone)]
+    struct TestProvider {
+        data: Bytes,
+    }
+
+    impl TestProvider {
+        fn new(data: Bytes) -> Self {
+            Self { data }
+        }
+    }
+
+    impl Provider for TestProvider {
+        fn reader_for(&self, _hash: &Hash) -> Option<DynVirtualSource> {
+            Some(Arc::new(self.data.clone()))
+        }
+    }
+
+    /// A virtual blob: build the outboard from a stream without storing data,
+    /// associate a provider, register it, and serve it. The served bytes must
+    /// be byte-identical to a normally-stored blob of the same content, and
+    /// must round-trip back to the original data through `import_bao`.
+    #[tokio::test]
+    async fn virtual_blob_roundtrip() -> TestResult<()> {
+        use std::sync::Arc;
+
+        let data = Bytes::from(
+            (0..1024 * 64)
+                .map(|i| (i & 0xff) as u8)
+                .collect::<Vec<u8>>(),
+        );
+        let (store, virtuals) = MemStore::new_with_virtuals(Options::default());
+
+        // Build the outboard from a stream of the data, without storing it.
+        let stream = n0_future::stream::iter(vec![Ok::<_, io::Error>(data.clone())]);
+        let tt = store.build_outboard(stream).await.temp_tag().await?;
+        let hash = tt.hash();
+
+        // An entry with no provider declared is served as not found.
+        let err: crate::api::Error = store
+            .export_bao(hash, ChunkRanges::all())
+            .bao_to_vec()
+            .await
+            .unwrap_err()
+            .into();
+        assert!(
+            matches!(err, crate::api::Error::Io(e) if e.kind() == io::ErrorKind::NotFound),
+            "virtual entry without a provider must serve as not found"
+        );
+
+        // Declaring a provider that is not registered is still not found.
+        store.add_virtual(hash, "test-provider").await?;
+        let err: crate::api::Error = store
+            .export_bao(hash, ChunkRanges::all())
+            .bao_to_vec()
+            .await
+            .unwrap_err()
+            .into();
+        assert!(
+            matches!(err, crate::api::Error::Io(e) if e.kind() == io::ErrorKind::NotFound),
+            "virtual entry with an unregistered provider must serve as not found"
+        );
+
+        // Register the provider and serve.
+        virtuals.register("test-provider", Arc::new(TestProvider::new(data.clone())))?;
+        let exported_virtual = store
+            .export_bao(hash, ChunkRanges::all())
+            .bao_to_vec()
+            .await?;
+
+        // Serving the virtual entry must match a normal stored blob exactly.
+        let store2 = MemStore::new();
+        let tt2 = store2.add_bytes(data.clone()).temp_tag().await?;
+        assert_eq!(tt2.hash(), hash, "hashes must match for identical content");
+        let exported_stored = store2
+            .export_bao(hash, ChunkRanges::all())
+            .bao_to_vec()
+            .await?;
+        assert_eq!(
+            exported_virtual, exported_stored,
+            "virtual export must be byte-identical to stored export"
+        );
+
+        // The encoded bytes round-trip through import_bao back to the data.
+        let store3 = MemStore::new();
+        store3
+            .import_bao_bytes(hash, ChunkRanges::all(), exported_virtual.clone())
+            .await?;
+        let got = store3.get_bytes(hash).await?;
+        assert_eq!(got, data, "round-tripped data must match the original");
+
+        Ok(())
+    }
+    /// A stored (Complete) blob must win over a virtual entry for the same hash.
+    ///
+    /// Storing a blob then building an outboard for the same hash is a no-op
+    /// on the entry (it stays `Complete`), so attaching a provider correctly
+    /// errors and serving uses the stored data.
+    #[tokio::test]
+    async fn virtual_entry_does_not_shadow_stored_blob() -> TestResult<()> {
+        let data = Bytes::from(
+            (0..1024 * 32)
+                .map(|i| (i & 0xff) as u8)
+                .collect::<Vec<u8>>(),
+        );
+        let (store, _virtuals) = MemStore::new_with_virtuals(Options::default());
+
+        // Store the blob normally (Complete).
+        let tt = store.add_bytes(data.clone()).temp_tag().await?;
+        let hash = tt.hash();
+
+        // build_outboard for the same hash is a no-op on the entry, which
+        // stays Complete (store-before-virtual precedence).
+        let stream = n0_future::stream::iter(vec![Ok::<_, io::Error>(data.clone())]);
+        let _tt2 = store.build_outboard(stream).await.temp_tag().await?;
+
+        // The entry is not virtual, so a provider cannot be attached.
+        assert!(
+            store.add_virtual(hash, "test-provider").await.is_err(),
+            "add_virtual must fail for a stored (non-virtual) entry"
+        );
+
+        // Serving uses the stored data.
+        let exported = store
+            .export_bao(hash, ChunkRanges::all())
+            .bao_to_vec()
+            .await?;
+        let store2 = MemStore::new();
+        store2
+            .import_bao_bytes(hash, ChunkRanges::all(), exported)
+            .await?;
+        let got = store2.get_bytes(hash).await?;
+        assert_eq!(got, data, "stored data must be served");
         Ok(())
     }
 }

--- a/src/store/mem.rs
+++ b/src/store/mem.rs
@@ -291,7 +291,8 @@ impl Actor {
             }) => {
                 // The outboard must match the size: one 64-byte hash pair per
                 // non-root tree node, and nothing at all for a single-chunk blob.
-                let res = if outboard.len() as u64 != BaoTree::new(size, IROH_BLOCK_SIZE).outboard_size()
+                let res = if outboard.len() as u64
+                    != BaoTree::new(size, IROH_BLOCK_SIZE).outboard_size()
                 {
                     Err(api::Error::io(
                         io::ErrorKind::InvalidInput,
@@ -299,18 +300,21 @@ impl Actor {
                     ))
                 } else {
                     let entry = self.get_or_create_entry(hash);
-                    let modified = entry.0.state.send_if_modified(|state: &mut BaoFileStorage| {
-                        // Stored data takes precedence over a virtual source.
-                        if matches!(state.deref(), BaoFileStorage::Complete(_)) {
-                            return false;
-                        }
-                        *state = BaoFileStorage::Virtual(VirtualStorage::new(
-                            outboard.clone(),
-                            size,
-                            provider.clone(),
-                        ));
-                        true
-                    });
+                    let modified = entry
+                        .0
+                        .state
+                        .send_if_modified(|state: &mut BaoFileStorage| {
+                            // Stored data takes precedence over a virtual source.
+                            if matches!(state.deref(), BaoFileStorage::Complete(_)) {
+                                return false;
+                            }
+                            *state = BaoFileStorage::Virtual(VirtualStorage::new(
+                                outboard.clone(),
+                                size,
+                                provider.clone(),
+                            ));
+                            true
+                        });
                     if modified {
                         Ok(())
                     } else {

--- a/src/store/mod.rs
+++ b/src/store/mod.rs
@@ -13,6 +13,8 @@ pub mod mem;
 pub mod readonly_mem;
 mod test;
 pub(crate) mod util;
+/// Live data sources for virtual blobs.
+pub mod virtual_blob;
 
 /// Block size used by iroh, 2^4*1024 = 16KiB
 pub const IROH_BLOCK_SIZE: BlockSize = BlockSize::from_chunk_log(4);

--- a/src/store/readonly_mem.rs
+++ b/src/store/readonly_mem.rs
@@ -36,10 +36,10 @@ use crate::{
         self,
         blobs::{Bitfield, ExportProgressItem},
         proto::{
-            self, BlobStatus, Command, ExportBaoMsg, ExportBaoRequest, ExportPathMsg,
-            ExportPathRequest, ExportRangesItem, ExportRangesMsg, ExportRangesRequest,
-            ImportBaoMsg, ImportByteStreamMsg, ImportBytesMsg, ImportPathMsg, ObserveMsg,
-            ObserveRequest, WaitIdleMsg,
+            self, AddVirtualMsg, AddVirtualWithOutboardMsg, BlobStatus, BuildOutboardMsg, Command,
+            ExportBaoMsg, ExportBaoRequest, ExportPathMsg, ExportPathRequest, ExportRangesItem,
+            ExportRangesMsg, ExportRangesRequest, ImportBaoMsg, ImportByteStreamMsg,
+            ImportBytesMsg, ImportPathMsg, ObserveMsg, ObserveRequest, WaitIdleMsg,
         },
         ApiClient, TempTag,
     },
@@ -118,6 +118,23 @@ impl Actor {
                 tx.send(unsupported("import not supported").into())
                     .await
                     .ok();
+            }
+            Command::BuildOutboard(BuildOutboardMsg { tx, .. }) => {
+                tx.send(unsupported("build_outboard not supported").into())
+                    .await
+                    .ok();
+            }
+            Command::AddVirtual(AddVirtualMsg { tx, .. }) => {
+                tx.send(Err(unsupported("add_virtual not supported").into()))
+                    .await
+                    .ok();
+            }
+            Command::AddVirtualWithOutboard(AddVirtualWithOutboardMsg { tx, .. }) => {
+                tx.send(Err(
+                    unsupported("add_virtual_with_outboard not supported").into()
+                ))
+                .await
+                .ok();
             }
             Command::ImportPath(ImportPathMsg { tx, .. }) => {
                 tx.send(unsupported("import not supported").into())

--- a/src/store/virtual_blob.rs
+++ b/src/store/virtual_blob.rs
@@ -1,0 +1,119 @@
+//! Providers of live data for virtual blobs.
+//!
+//! A virtual blob is a store entry that has an outboard but no stored data.
+//! Instead, its data is produced on demand by an externally-registered
+//! provider. This is used to serve a blob whose bytes are a transform (e.g.
+//! encryption, compression) of another blob, without materializing the
+//! transformed bytes.
+//!
+//! Each virtual entry durably stores the name of the provider that serves it
+//! (see [`crate::api::blobs::Blobs::add_virtual`]). The [`VirtualProviders`]
+//! registry is an in-process, shared map from provider name to a live
+//! [`Provider`]. It is constructed alongside a store and shared between the
+//! store actor (which consults it when serving a virtual entry) and the
+//! application (which registers providers via
+//! [`VirtualProviders::register`]). Because a live provider is not
+//! serializable, this registry is intentionally local-only and never crosses
+//! an RPC channel.
+//!
+//! The stored outboard and provider name are what make a virtual entry durable
+//! across restarts: iroh-blobs keeps both in its database, while the
+//! application re-registers its providers on startup from its own state. An
+//! entry whose provider is not registered (or whose provider returns `None`
+//! for its hash) is served as not found.
+use std::{
+    collections::HashMap,
+    io,
+    sync::{Arc, Mutex},
+};
+
+use bao_tree::io::mixed::ReadBytesAt;
+use bytes::Bytes;
+
+use crate::Hash;
+
+/// A boxed, thread-safe live data source for a virtual blob.
+pub type DynVirtualSource = Arc<dyn ReadBytesAt + Send + Sync>;
+
+/// A provider of data for virtual blobs.
+///
+/// A provider is registered under an application-chosen name and can be asked
+/// for a random-access reader for a given hash. It returns `None` if it does
+/// not serve that hash.
+pub trait Provider: Send + Sync + 'static {
+    /// Return a random-access reader for `hash`, or `None` if this provider
+    /// does not serve that hash.
+    fn reader_for(&self, hash: &Hash) -> Option<DynVirtualSource>;
+}
+
+/// A boxed, thread-safe provider.
+pub type DynProvider = Arc<dyn Provider>;
+
+/// A registry of live providers for virtual blobs, shared between a store
+/// actor and the application.
+#[derive(Clone, Default)]
+pub struct VirtualProviders {
+    inner: Arc<Mutex<HashMap<String, DynProvider>>>,
+}
+
+impl std::fmt::Debug for VirtualProviders {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let len = self
+            .inner
+            .lock()
+            .expect("virtual providers lock poisoned")
+            .len();
+        f.debug_struct("VirtualProviders")
+            .field("len", &len)
+            .finish()
+    }
+}
+
+impl VirtualProviders {
+    /// Create an empty registry.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(HashMap::new())),
+        }
+    }
+
+    /// Register a provider under `name`.
+    ///
+    /// Re-registering a name replaces the previous provider. This is intended
+    /// to be idempotent so that an application can register providers on
+    /// startup without coordination.
+    pub fn register(&self, name: impl Into<String>, provider: DynProvider) -> io::Result<()> {
+        let mut map = self.inner.lock().expect("virtual providers lock poisoned");
+        map.insert(name.into(), provider);
+        Ok(())
+    }
+
+    /// Unregister the provider registered under `name`, if any.
+    pub fn unregister(&self, name: impl AsRef<str>) {
+        self.inner
+            .lock()
+            .expect("virtual providers lock poisoned")
+            .remove(name.as_ref());
+    }
+
+    /// Look up the provider registered under `name`, if any.
+    pub fn get(&self, name: &str) -> Option<DynProvider> {
+        self.inner
+            .lock()
+            .expect("virtual providers lock poisoned")
+            .get(name)
+            .cloned()
+    }
+}
+
+/// A wrapper that lets a boxed [`ReadBytesAt`] trait object be passed by value
+/// to functions generic over `D: ReadBytesAt` (such as
+/// [`bao_tree::io::mixed::traverse_ranges_validated`]).
+#[derive(Clone)]
+pub struct DynReadBytesAt(pub DynVirtualSource);
+
+impl ReadBytesAt for DynReadBytesAt {
+    fn read_bytes_at(&self, offset: u64, size: usize) -> io::Result<Bytes> {
+        self.0.read_bytes_at(offset, size)
+    }
+}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -253,6 +253,271 @@ async fn two_nodes_get_blobs_mem() -> TestResult<()> {
     two_nodes_get_blobs(r1, &store1, r2, &store2).await
 }
 
+/// `fetch_bao_to` downloads a single blob's verified `BaoContentItem`s into a
+/// caller-provided channel without importing into a store. Reassembling the
+/// leaf items must yield the original bytes; this is the getter-side half of
+/// the virtual blob API.
+#[tokio::test]
+async fn fetch_bao_to_downloads_verified_items() -> TestResult<()> {
+    use bao_tree::io::BaoContentItem;
+
+    let ((r1, store1), (r2, store2)) = two_node_test_setup_mem().await?;
+    let data = test_data(1024 * 64);
+    let hash = Hash::new(data.clone());
+    let _tt = store1.add_bytes(data.clone()).await?;
+
+    let conn = r2
+        .endpoint()
+        .connect(r1.endpoint().addr(), crate::ALPN)
+        .await?;
+
+    let (tx, mut rx) = irpc::channel::mpsc::channel::<BaoContentItem>(64);
+    let consumer = tokio::spawn(async move {
+        let mut assembled = Vec::new();
+        let mut parents = 0u64;
+        while let Ok(Some(item)) = rx.recv().await {
+            match item {
+                BaoContentItem::Leaf(leaf) => assembled.extend_from_slice(&leaf.data),
+                BaoContentItem::Parent(_) => parents += 1,
+            }
+        }
+        (assembled, parents)
+    });
+
+    let _stats = store2.remote().fetch_bao_to(conn, hash, tx).await?;
+    let (assembled, parents) = consumer.await?;
+
+    assert_eq!(
+        assembled.as_slice(),
+        data.as_ref(),
+        "reassembled leaves must match the original blob"
+    );
+    // A 64KiB blob spans multiple bao chunks, so the outboard (parents) is non-empty.
+    assert!(
+        parents > 0,
+        "expected non-empty outboard for a multi-chunk blob"
+    );
+
+    tokio::try_join!(r1.shutdown(), r2.shutdown())?;
+    Ok(())
+}
+
+/// A provider that serves a fixed set of bytes for any hash.
+#[derive(Clone)]
+struct TestBytesProvider {
+    data: Bytes,
+}
+
+impl crate::store::virtual_blob::Provider for TestBytesProvider {
+    fn reader_for(
+        &self,
+        _hash: &crate::Hash,
+    ) -> Option<crate::store::virtual_blob::DynVirtualSource> {
+        use std::sync::Arc;
+        Some(Arc::new(self.data.clone()))
+    }
+}
+
+/// Sets up a mem node that exposes its [`crate::store::virtual_blob::VirtualProviders`] handle.
+async fn node_test_setup_mem_with_virtuals(
+) -> TestResult<(Router, MemStore, MemoryLookup, crate::store::virtual_blob::VirtualProviders)> {
+    let (store, virtuals) = MemStore::new_with_virtuals(Default::default());
+    let sp = MemoryLookup::new();
+    let ep = Endpoint::builder(presets::Minimal)
+        .relay_mode(RelayMode::Default)
+        .address_lookup(sp.clone())
+        .bind()
+        .await?;
+    let blobs = BlobsProtocol::new(&store, Some(EventSender::DEFAULT));
+    let router = Router::builder(ep).accept(crate::ALPN, blobs).spawn();
+    Ok((router, store, sp, virtuals))
+}
+
+/// Full getter-side virtual flow over the wire: node A stores X normally; node
+/// B fetches X's verified content without importing it, assembles the received
+/// parent items into an outboard, installs it as a virtual entry via
+/// `add_virtual_with_outboard`, and serves X to node C by re-providing the
+/// bytes from its own copy. Node C must receive the correct bytes. Also
+/// covers the negative case: before the provider is registered on B, C's GET
+/// must fail.
+#[tokio::test]
+async fn two_nodes_get_virtual_blob_served_from_outboard() -> TestResult<()> {
+    use bao_tree::io::BaoContentItem;
+    use std::sync::Arc;
+
+    let ((r1, store1), _sp1) = {
+        let (r1, store1, sp1) = node_test_setup_mem().await?;
+        ((r1, store1), sp1)
+    };
+    let (r2, store2, sp2, virtuals2) = node_test_setup_mem_with_virtuals().await?;
+    let (r3, store3, _sp3) = node_test_setup_mem().await?;
+    // tell the nodes about each other so we don't rely on address lookup
+    sp2.add_endpoint_info(r1.endpoint().addr());
+    sp2.add_endpoint_info(r3.endpoint().addr());
+    let _ = _sp1;
+
+    let data = test_data(1024 * 64);
+    let hash = Hash::new(data.clone());
+    store1.add_bytes(data.clone()).temp_tag().await?;
+
+    // Node B fetches X from A without importing: leaves are discarded (the
+    // point of the virtual flow is to not retain them), parents are assembled
+    // into the standard pre-order outboard serialization.
+    let conn_b_a = r2
+        .endpoint()
+        .connect(r1.endpoint().addr(), crate::ALPN)
+        .await?;
+    let (item_tx, mut item_rx) = irpc::channel::mpsc::channel::<BaoContentItem>(64);
+    let stats = store2.remote().fetch_bao_to(conn_b_a, hash, item_tx).await?;
+    assert!(stats.payload_bytes_read > 0);
+    let mut leaves = Vec::new();
+    let mut outboard = Vec::new();
+    while let Some(Some(item)) = item_rx.recv().await.ok() {
+        match item {
+            BaoContentItem::Leaf(leaf) => leaves.extend_from_slice(&leaf.data),
+            BaoContentItem::Parent(parent) => {
+                outboard.extend_from_slice(parent.pair.0.as_bytes());
+                outboard.extend_from_slice(parent.pair.1.as_bytes());
+            }
+            other => panic!("unexpected content item {other:?}"),
+        }
+    }
+    assert_eq!(leaves, data.as_ref(), "reassembled leaves must match");
+    assert!(!outboard.is_empty(), "multi-chunk blob must have an outboard");
+
+    // Install the virtual entry from the received outboard.
+    store2
+        .blobs()
+        .add_virtual_with_outboard(hash, data.len() as u64, outboard, "test-provider")
+        .await?;
+
+    // Negative case: no provider registered yet, so serving must fail.
+    let conn_c_b = r3
+        .endpoint()
+        .connect(r2.endpoint().addr(), crate::ALPN)
+        .await?;
+    let err = store3
+        .remote()
+        .fetch(conn_c_b.clone(), hash)
+        .await
+        .unwrap_err();
+    info!(%err, "GET without registered provider failed as expected");
+
+    // Register the provider backing the virtual entry with the bytes, and now
+    // node C must be able to GET the blob from node B.
+    virtuals2.register(
+        "test-provider",
+        Arc::new(TestBytesProvider {
+            data: data.clone(),
+        }),
+    )?;
+    store3.remote().fetch(conn_c_b, hash).await?;
+    let got = store3.get_bytes(hash).await?;
+    assert_eq!(got, data, "node C must receive the exact bytes");
+
+    tokio::try_join!(r1.shutdown(), r2.shutdown(), r3.shutdown())?;
+    Ok(())
+}
+
+/// `add_virtual_with_outboard` placement rules on the fs store: empty outboard
+/// needs no file, small outboards are inlined, large outboards go to the
+/// canonical outboard file location - and all three serve correctly.
+#[tokio::test]
+async fn add_virtual_with_outboard_fs_placement() -> TestResult<()> {
+    use std::sync::Arc;
+    use crate::store::virtual_blob::{DynVirtualSource, Provider};
+
+    struct FixedProvider(Bytes);
+    impl Provider for FixedProvider {
+        fn reader_for(&self, _hash: &Hash) -> Option<DynVirtualSource> {
+            Some(Arc::new(self.0.clone()))
+        }
+    }
+
+    let testdir = tempfile::tempdir()?;
+    let options = crate::store::fs::options::Options::new(testdir.path());
+    let (store, virtuals) = crate::store::fs::FsStore::load_with_virtuals(
+        testdir.path().join("blobs.db"),
+        options.clone(),
+    )
+    .await?;
+
+    // single chunk: empty outboard => NotNeeded
+    let small = test_data(1024);
+    let small_hash = Hash::new(small.clone());
+    store
+        .blobs()
+        .add_virtual_with_outboard(small_hash, small.len() as u64, Bytes::new(), "p")
+        .await?;
+
+    // multi-chunk but tiny tree: inline outboard
+    let medium = test_data(256 * 1024);
+    let medium_hash = Hash::new(medium.clone());
+    let medium_outboard =
+        bao_tree::io::outboard::PreOrderMemOutboard::create(&medium, crate::store::IROH_BLOCK_SIZE);
+    store
+        .blobs()
+        .add_virtual_with_outboard(
+            medium_hash,
+            medium.len() as u64,
+            medium_outboard.data.clone(),
+            "p",
+        )
+        .await?;
+    assert!(
+        !options.path.outboard_path(&medium_hash).exists(),
+        "small outboard must be inlined, not written to a file"
+    );
+
+    // large blob: outboard above the default 16KiB inline threshold => file
+    let large = test_data(1024 * 1024 * 8);
+    let large_hash = Hash::new(large.clone());
+    let large_outboard =
+        bao_tree::io::outboard::PreOrderMemOutboard::create(&large, crate::store::IROH_BLOCK_SIZE);
+    store
+        .blobs()
+        .add_virtual_with_outboard(
+            large_hash,
+            large.len() as u64,
+            large_outboard.data.clone(),
+            "p",
+        )
+        .await?;
+    assert!(
+        options.path.outboard_path(&large_hash).exists(),
+        "large outboard must live at the canonical outboard file location"
+    );
+
+    // A stored entry for the same hash must be rejected.
+    let stored = store.blobs().add_bytes(medium.clone()).temp_tag().await?;
+    assert_eq!(stored.hash(), medium_hash);
+    let err = store
+        .blobs()
+        .add_virtual_with_outboard(medium_hash, medium.len() as u64, Bytes::new(), "p")
+        .await
+        .unwrap_err();
+    info!(%err, "adding virtual entry over stored data failed as expected");
+    drop(stored);
+
+    // All three entries must serve byte-identical to normal storage.
+    virtuals.register("p", Arc::new(FixedProvider(small.clone())))?;
+    let served = store
+        .blobs()
+        .export_bao(small_hash, ChunkRanges::all())
+        .bao_to_vec()
+        .await?;
+    let reference = crate::api::Store::from(crate::store::mem::MemStore::new());
+    let tt = reference.add_bytes(small.clone()).temp_tag().await?;
+    let expected = reference
+        .export_bao(tt.hash(), ChunkRanges::all())
+        .bao_to_vec()
+        .await?;
+    assert_eq!(served, expected);
+
+    tokio::try_join!(store.shutdown()).ok();
+    Ok(())
+}
+
 async fn two_nodes_observe(
     r1: Router,
     store1: &Store,

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -284,7 +284,10 @@ async fn fetch_bao_to_downloads_verified_items() -> TestResult<()> {
         (assembled, parents)
     });
 
-    let _stats = store2.remote().fetch_bao_to(conn, hash, tx).await?;
+    let _stats = store2
+        .remote()
+        .fetch_bao_to(conn, hash, bao_tree::ChunkRanges::all(), tx)
+        .await?;
     let (assembled, parents) = consumer.await?;
 
     assert_eq!(
@@ -296,6 +299,73 @@ async fn fetch_bao_to_downloads_verified_items() -> TestResult<()> {
     assert!(
         parents > 0,
         "expected non-empty outboard for a multi-chunk blob"
+    );
+
+    tokio::try_join!(r1.shutdown(), r2.shutdown())?;
+    Ok(())
+}
+
+/// `fetch_bao_to` with explicit ranges: only the requested chunk window is
+/// delivered (a seek), and the received leaves are byte-identical to that
+/// window of the original blob. This is the primitive a transform receiver
+/// uses to resume from its own progress watermark.
+#[tokio::test]
+async fn fetch_bao_to_ranged_window() -> TestResult<()> {
+    use bao_tree::io::BaoContentItem;
+
+    let ((r1, store1), (r2, _store2)) = two_node_test_setup_mem().await?;
+    // 1 KiB = one blake3 chunk; 1 MiB = 1024 chunks.
+    let data = test_data(1024 * 1024);
+    let hash = Hash::new(data.clone());
+    let _tt = store1.add_bytes(data.clone()).await?;
+
+    let conn = r2
+        .endpoint()
+        .connect(r1.endpoint().addr(), crate::ALPN)
+        .await?;
+
+    // Chunk ranges are 1 KiB blake3-chunk units: request chunks 2..5 =
+    // bytes [2048, 5120).
+    let start_byte = 2u64 * 1024;
+    let end_byte = 5u64 * 1024;
+    use bao_tree::ChunkNum;
+    let ranges = bao_tree::ChunkRanges::from(ChunkNum(2)..ChunkNum(5));
+
+    let (tx, mut rx) = irpc::channel::mpsc::channel::<BaoContentItem>(64);
+    let consumer = tokio::spawn(async move {
+        let mut assembled = Vec::new();
+        let mut first_offset = None;
+        let mut last_end = 0u64;
+        while let Ok(Some(item)) = rx.recv().await {
+            match item {
+                BaoContentItem::Leaf(leaf) => {
+                    let off = leaf.offset;
+                    first_offset.get_or_insert(off);
+                    last_end = off + leaf.data.len() as u64;
+                    assembled.extend_from_slice(&leaf.data);
+                }
+                BaoContentItem::Parent(_) => {}
+            }
+        }
+        (assembled, first_offset, last_end)
+    });
+
+    let stats = _store2
+        .remote()
+        .fetch_bao_to(conn, hash, ranges, tx)
+        .await?;
+    assert_eq!(
+        stats.payload_bytes_read as u64,
+        end_byte - start_byte,
+        "only the requested window must be transferred"
+    );
+    let (assembled, first_offset, last_end) = consumer.await?;
+    assert_eq!(first_offset.unwrap_or(0), start_byte);
+    assert_eq!(last_end, end_byte);
+    assert_eq!(
+        assembled.as_slice(),
+        &data.as_ref()[start_byte as usize..end_byte as usize],
+        "window bytes must match the original blob"
     );
 
     tokio::try_join!(r1.shutdown(), r2.shutdown())?;
@@ -319,8 +389,12 @@ impl crate::store::virtual_blob::Provider for TestBytesProvider {
 }
 
 /// Sets up a mem node that exposes its [`crate::store::virtual_blob::VirtualProviders`] handle.
-async fn node_test_setup_mem_with_virtuals(
-) -> TestResult<(Router, MemStore, MemoryLookup, crate::store::virtual_blob::VirtualProviders)> {
+async fn node_test_setup_mem_with_virtuals() -> TestResult<(
+    Router,
+    MemStore,
+    MemoryLookup,
+    crate::store::virtual_blob::VirtualProviders,
+)> {
     let (store, virtuals) = MemStore::new_with_virtuals(Default::default());
     let sp = MemoryLookup::new();
     let ep = Endpoint::builder(presets::Minimal)
@@ -368,7 +442,10 @@ async fn two_nodes_get_virtual_blob_served_from_outboard() -> TestResult<()> {
         .connect(r1.endpoint().addr(), crate::ALPN)
         .await?;
     let (item_tx, mut item_rx) = irpc::channel::mpsc::channel::<BaoContentItem>(64);
-    let stats = store2.remote().fetch_bao_to(conn_b_a, hash, item_tx).await?;
+    let stats = store2
+        .remote()
+        .fetch_bao_to(conn_b_a, hash, bao_tree::ChunkRanges::all(), item_tx)
+        .await?;
     assert!(stats.payload_bytes_read > 0);
     let mut leaves = Vec::new();
     let mut outboard = Vec::new();
@@ -383,7 +460,10 @@ async fn two_nodes_get_virtual_blob_served_from_outboard() -> TestResult<()> {
         }
     }
     assert_eq!(leaves, data.as_ref(), "reassembled leaves must match");
-    assert!(!outboard.is_empty(), "multi-chunk blob must have an outboard");
+    assert!(
+        !outboard.is_empty(),
+        "multi-chunk blob must have an outboard"
+    );
 
     // Install the virtual entry from the received outboard.
     store2
@@ -407,9 +487,7 @@ async fn two_nodes_get_virtual_blob_served_from_outboard() -> TestResult<()> {
     // node C must be able to GET the blob from node B.
     virtuals2.register(
         "test-provider",
-        Arc::new(TestBytesProvider {
-            data: data.clone(),
-        }),
+        Arc::new(TestBytesProvider { data: data.clone() }),
     )?;
     store3.remote().fetch(conn_c_b, hash).await?;
     let got = store3.get_bytes(hash).await?;
@@ -424,8 +502,8 @@ async fn two_nodes_get_virtual_blob_served_from_outboard() -> TestResult<()> {
 /// canonical outboard file location - and all three serve correctly.
 #[tokio::test]
 async fn add_virtual_with_outboard_fs_placement() -> TestResult<()> {
-    use std::sync::Arc;
     use crate::store::virtual_blob::{DynVirtualSource, Provider};
+    use std::sync::Arc;
 
     struct FixedProvider(Bytes);
     impl Provider for FixedProvider {


### PR DESCRIPTION
## Description

Adds support for virtual blobs. Store the outboard but provide the data later using VirtualProviders. Target usecase is serving encrypted versions of a blob that's stored in plaintext. I.e. hen one wants to read the plaintext locally (no encryption at rest) and cheaply but still support serving encrypted blobs on demand.

Look at the attached example for more details.

## Breaking Changes

- Store implementations must now support the new virtual blob related requests.

## Notes & open questions

n/a

## Change checklist

- [x] Self-review.
- [ ] Documentation updates following the [style guide](https://rust-lang.github.io/rfcs/1574-more-api-documentation-conventions.html#appendix-a-full-conventions-text), if relevant.
- [x] Tests if relevant.
- [x] All breaking changes documented.
