### PR TITLE
feat(api): make ApiClient public and add Store::local for custom backends

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -30,11 +30,7 @@ pub mod tags;
 use crate::{api::proto::WaitIdleRequest, provider::events::ProgressError};
 pub use crate::{store::util::Tag, util::temp_tag::TempTag};
 
-/// The local rpc client type backing an in-process [`Store`].
-///
-/// Public so that external crates can implement custom store backends:
-/// serve the [`proto::Request`] protocol on a local channel and wrap the
-/// client end with [`Store::local`].
+/// The type of the local rpc client backing a [`Store`].
 pub type ApiClient = irpc::Client<proto::Request>;
 
 #[allow(missing_docs)]
@@ -301,17 +297,7 @@ impl Store {
         Ok(())
     }
 
-    /// Create a store API from a custom local rpc client.
-    ///
-    /// This is the extension point for custom store backends implemented
-    /// outside of this crate (e.g. browser storage): spawn an actor serving
-    /// the [`proto::Request`] protocol and wrap the client end:
-    ///
-    /// ```ignore
-    /// let (tx, rx) = tokio::sync::mpsc::channel(32);
-    /// // spawn your actor on `rx` ...
-    /// let store = iroh_blobs::api::Store::local(tx.into());
-    /// ```
+    /// Create a store from a custom local rpc client.
     pub fn local(client: ApiClient) -> Self {
         Self { client }
     }

--- a/src/api.rs
+++ b/src/api.rs
@@ -30,7 +30,12 @@ pub mod tags;
 use crate::{api::proto::WaitIdleRequest, provider::events::ProgressError};
 pub use crate::{store::util::Tag, util::temp_tag::TempTag};
 
-pub(crate) type ApiClient = irpc::Client<proto::Request>;
+/// The local rpc client type backing an in-process [`Store`].
+///
+/// Public so that external crates can implement custom store backends:
+/// serve the [`proto::Request`] protocol on a local channel and wrap the
+/// client end with [`Store::local`].
+pub type ApiClient = irpc::Client<proto::Request>;
 
 #[allow(missing_docs)]
 #[non_exhaustive]
@@ -296,8 +301,23 @@ impl Store {
         Ok(())
     }
 
-    pub(crate) fn from_sender(client: ApiClient) -> Self {
+    /// Create a store API from a custom local rpc client.
+    ///
+    /// This is the extension point for custom store backends implemented
+    /// outside of this crate (e.g. browser storage): spawn an actor serving
+    /// the [`proto::Request`] protocol and wrap the client end:
+    ///
+    /// ```ignore
+    /// let (tx, rx) = tokio::sync::mpsc::channel(32);
+    /// // spawn your actor on `rx` ...
+    /// let store = iroh_blobs::api::Store::local(tx.into());
+    /// ```
+    pub fn local(client: ApiClient) -> Self {
         Self { client }
+    }
+
+    pub(crate) fn from_sender(client: ApiClient) -> Self {
+        Self::local(client)
     }
 
     pub(crate) fn ref_from_sender(client: &ApiClient) -> &Self {


### PR DESCRIPTION
## Motivation

`Store` was only constructible from in-crate backends (`MemStore`, `FsStore`) or via `Store::connect` (remote). External crates could not back a `Store` with a custom implementation (e.g. OPFS in the browser/WASM, in-memory test backend) by serving `proto::Request` on a local `irpc` channel, because `ApiClient` and the local constructor were `pub(crate)`.

## Changes

- Make `ApiClient` (`irpc::Client<proto::Request>`) public.
- Add `Store::local(client: ApiClient)` public constructor: create a `Store` from a custom local rpc client.
- Keep `Store::from_sender` as `pub(crate)` thin wrapper over `Store::local` (no breaking change).

## Example

```rust
let (client, rx) = irpc::channel::local(...); // serve proto::Request with your backend
tokio::spawn(async move { /* handle rx with custom backend, e.g. OPFS */ });
let store = Store::local(client);
```